### PR TITLE
Update status to use lockfile

### DIFF
--- a/wit
+++ b/wit
@@ -92,12 +92,12 @@ def add(ws, args):
 
 def status(ws, args):
     log.info("Checking workspace status")
-    for reponame in ws.manifest:
+    for reponame in ws.lock:
         print("Status for repo [{}]".format(reponame))
 
         # FIXME: cheating by diving into the object.
-        manifest_commit = ws.manifest[reponame]['commit']
-        latest_commit = GitRepo.create(ws.manifest[reponame]['source']).get_latest_commit()
+        manifest_commit = ws.lock[reponame]['commit']
+        latest_commit = GitRepo.create(ws.lock[reponame]['source'], dest=ws.path).get_latest_commit()
 
         print("    Manifest commit: {}".format(manifest_commit))
         print("    Latest commit:   {}".format(latest_commit))

--- a/workspace.py
+++ b/workspace.py
@@ -76,6 +76,7 @@ class WorkSpace:
                 self.path = p
 
                 self.read_manifest()
+                self.read_lockfile()
                 return
         
         raise FileNotFoundError("Couldn't find manifest file")
@@ -178,6 +179,9 @@ class WorkSpace:
         lockfile_json = json.dumps(self.lock, sort_keys=True, indent=4) + '\n'
         self.lockfile_path().write_text(lockfile_json)
 
+    def read_lockfile(self):
+        lockfile_json = self.lockfile_path().read_text()
+        self.lock = json.loads(lockfile_json)
 
     def write_manifest(self):
         manifest_json = json.dumps(self.manifest, sort_keys=True, indent=4) + '\n'


### PR DESCRIPTION
Partial fix to #5 

Pretty straightforward, the two things I'm not really sure about:

1. adding `dest=ws.path` to `GitRepo.create` call in `status`
1. I added `self.read_lockfile()` to `Workspace.find()`, it's really finding the manifest file so this might be wrong