### PR TITLE
Change wit status format, include more information

### DIFF
--- a/wit
+++ b/wit
@@ -16,6 +16,7 @@ from workspace import WorkSpace, GitRepo
 import logging
 import os
 import sys
+from collections import OrderedDict
 
 logging.basicConfig(level = logging.INFO)
 log = logging.getLogger('wit')
@@ -92,15 +93,35 @@ def add(ws, args):
 
 def status(ws, args):
     log.info("Checking workspace status")
+    clean = []
+    dirty = OrderedDict()
     for reponame in ws.lock:
-        print("Status for repo [{}]".format(reponame))
-
         # FIXME: cheating by diving into the object.
         manifest_commit = ws.lock[reponame]['commit']
-        latest_commit = GitRepo.create(ws.lock[reponame]['source'], dest=ws.path).get_latest_commit()
+        repo = GitRepo.create(ws.lock[reponame]['source'], dest=ws.path)
+        latest_commit = repo.get_latest_commit()
 
-        print("    Manifest commit: {}".format(manifest_commit))
-        print("    Latest commit:   {}".format(latest_commit))
+        new_commits = manifest_commit != latest_commit
+
+        if new_commits or not repo.clean():
+            status = []
+            if new_commits:
+                status.append("new commits")
+            if repo.modified():
+                status.append("modified content")
+            if repo.untracked():
+                status.append("untracked content")
+            dirty[reponame] = status
+        else:
+            clean.append(reponame)
+
+    print("Clean repos:")
+    for repo in clean:
+        print("    {}".format(repo))
+    print("Dirty repos:")
+    for repo, content in dirty.items():
+        msg = ", ".join(content)
+        print("    {} ({})".format(repo, msg))
 
 
 def update(ws, args):


### PR DESCRIPTION
**Note: This is a duplicate PR of #9, but this time against master**

This PR does 2 things:
1. Make the ordering of the lock file deterministic via OrderedDict
2. Change the output of `wit status`

Previously, `wit status` simply gave you the manifest and actual commits, this PR also will notify you of modified content and untracked content.

Sample `wit status` output:
```
$ wit status
INFO:wit:Checking [/scratch/koenig/freedom-wake/wit-manifest.json]
INFO:wit:Checking workspace status
Clean repos:
    berkeley-hardfloat
    chisel3
    chisel3-wake
    firrtl
    firrtl-wake
    rocket-chip
    rocket-chip-wake
Dirty repos:
    scala-wake (new commits, modified content, untracked content)
```

I copied the notions of "new commits", "modified content", and "untracked content" from `git status`. I'm not sure if copying git is the right idea here but I just picked it as a starting point.