### PR TITLE
Large refactor, split workspace into multiple files

### DIFF
--- a/gitrepo.py
+++ b/gitrepo.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+
+import subprocess
+import argparse
+from pathlib import Path
+import logging
+from pprint import pformat
+import manifest
+import json
+
+logging.basicConfig()
+log = logging.getLogger('wit')
+
+class GitError(Exception):
+    pass
+
+class GitRepo:
+    """
+    In memory data structure representing a Git repo package
+    It may not be in sync with data structures on the file system
+    Note there can be multiple GitRepo objects for the same package
+    """
+    WIT_DEPENDENCY_FILE = "wit-manifest.json"
+
+    def __init__(self, source, revision, name=None, path=None):
+        self.path = path
+        self.source = source
+        self.revision = revision
+        if name == None:
+            self.name = GitRepo.path_to_name(source)
+        else:
+            self.name = name
+
+    # FIXME
+    # Ideally we would always set the path on construction, but constructing
+    # GitRepo (see Package.from_arg) during argument parsing, we don't yet know
+    # the path
+    def set_path(self, wsroot):
+        assert self.path == None, "Trying to set path, but it has already been set!"
+        self.path = wsroot / self.name
+
+    def clone(self):
+        assert self.path is not None, "Path must be set before cloning!"
+        assert not GitRepo.is_git_repo(self.path), "Trying to clone and checkout into existing git repo!"
+
+        self.path.mkdir()
+
+        proc = self._git_command("clone", "--no-checkout", str(self.source), str(self.path))
+        try:
+            self._git_check(proc)
+        except Exception as e:
+            log.error("Error cloning into workspace: {}".format(e))
+            sys.exit(1)
+
+    def clone_and_checkout(self):
+        self.clone()
+        self.checkout()
+        # If our revision was a branch or tag, get the actual commit
+        self.revision = self.get_latest_commit()
+
+
+
+    def get_latest_commit(self):
+        proc = self._git_command('rev-parse', 'HEAD')
+        self._git_check(proc)
+        return proc.stdout.rstrip()
+
+    def clean(self):
+        proc = self._git_command('status', '--porcelain')
+        self._git_check(proc)
+        return proc.stdout == ""
+
+    def modified(self):
+        proc = self._git_command('status', '--porcelain')
+        self._git_check(proc)
+        for line in proc.stdout.split("\n"):
+            if line.lstrip().startswith("M"):
+                return True
+        return False
+
+    def untracked(self):
+        proc = self._git_command('status', '--porcelain')
+        self._git_check(proc)
+        for line in proc.stdout.split("\n"):
+            if line.lstrip().startswith("??"):
+                return True
+        return False
+
+
+    # TODO Since we're storing the revision, should we be passing it as an argument?
+    def commit_to_time(self, hash):
+        proc = self._git_command('log', '-n1', '--format=%ct', hash)
+        self._git_check(proc)
+        return proc.stdout.rstrip()
+
+
+    def is_ancestor(self, ancestor, current=None):
+        proc = self._git_command("merge-base", "--is-ancestor", ancestor, current or self.get_latest_commit())
+        return proc.returncode == 0
+
+
+    # FIXME should we pass wsroot or should it be a member of the GitRepo?
+    # Should this be a separate mutation or part of normal construction?
+    def get_dependencies(self, wsroot):
+        proc = self._git_command("show", "{}:{}".format(self.revision, GitRepo.WIT_DEPENDENCY_FILE))
+        if proc.returncode:
+            log.info("No dependency file found in repo [{}:{}]".format(self.revision, self.path))
+            return []
+        json_content = json.loads(proc.stdout)
+        return manifest.Manifest.process_manifest(wsroot, json_content).packages
+
+    def checkout(self):
+        proc = self._git_command("checkout", self.revision)
+        self._git_check(proc)
+
+
+    def manifest(self):
+        return {
+            'name': self.name,
+            'source': self.source,
+            'commit': self.revision,
+        }
+
+
+    def _git_command(self, *args):
+        log.debug("Executing [{}] in [{}]".format(' '.join(['git', *args]), self.path))
+        proc = subprocess.run(['git', *args], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            cwd=str(self.path), universal_newlines=True)
+        return proc
+
+
+    def _git_check(self, proc):
+        if proc.returncode:
+            log.error("Command [{}] exited with non-zero exit status [{}]".format(' '.join(proc.args), proc.returncode))
+            log.error("stdout: [{}]".format(proc.stdout.rstrip()))
+            log.error("stderr: [{}]".format(proc.stderr.rstrip()))
+            raise GitError(proc.stderr.rstrip())
+
+        return proc.returncode
+
+
+    @staticmethod
+    def path_to_name(path):
+        """
+        >>> GitRepo.path_to_name("a.git")
+        'a'
+        >>> GitRepo.path_to_name("/a/b/c/def.git")
+        'def'
+        >>> GitRepo.path_to_name("ghi")
+        'ghi'
+        """
+        return Path(path).name.replace('.git', '')
+
+    @staticmethod
+    def is_git_repo(path):
+        cmd = ['git', 'ls-remote', '--exit-code', path]
+        proc = subprocess.run(cmd, capture_output=True)
+        ret = proc.returncode
+        return ret == 0
+
+
+    # Enable prettyish-printing of the class
+    def __repr__(self):
+        return pformat(vars(self), indent=4, width=1)
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()
+

--- a/lock.py
+++ b/lock.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import json
+from package import Package
+from collections import OrderedDict
+import logging
+
+logging.basicConfig()
+log = logging.getLogger('wit')
+
+# TODO
+# Should we use different datastructures?
+# The JSON file format slightly differs from manifest, why?
+class LockFile:
+    """
+    Common class for the description of package dependencies and a workspace
+    """
+
+    def __init__(self, packages=[]):
+        self.packages = packages
+
+    def contains_package(self, package):
+        for p in self.packages:
+            if p.name == package.name:
+                return True
+        return False
+
+    def add_package(self, package):
+        self.packages.append(package)
+
+    def write(self, path):
+        log.debug("Writing lock file to {}".format(path))
+        contents = OrderedDict((p.name, p.manifest()) for p in self.packages)
+        manifest_json = json.dumps(contents, sort_keys=True, indent=4) + '\n'
+        path.write_text(manifest_json)
+
+    @staticmethod
+    def read(path):
+        log.debug("Reading lock file from {}".format(path))
+        content = json.loads(path.read_text())
+        wsroot = path.parent
+        return LockFile.process(wsroot, content)
+
+    @staticmethod
+    def process(wsroot, content):
+        packages = [Package.from_manifest(wsroot, x) for _, x in content.items()]
+        return LockFile(packages)
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/manifest.py
+++ b/manifest.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import json
+from package import Package
+
+# TODO
+# Should this actually be shared between package manifests and workspace descriptions?
+# Should we use different datastructures?
+class Manifest:
+    """
+    Common class for the description of package dependencies and a workspace
+    """
+
+    def __init__(self, packages):
+        self.packages = packages
+
+    def contains_package(self, package):
+        for p in self.packages:
+            if p.name == package.name:
+                return True
+        return False
+
+    def add_package(self, package):
+        self.packages.append(package)
+
+    def write(self, path):
+        contents = [p.manifest() for p in self.packages]
+        manifest_json = json.dumps(contents, sort_keys=True, indent=4) + '\n'
+        path.write_text(manifest_json)
+
+    # FIXME It's maybe a little weird that we need wsroot but that's because
+    # this method is being used for both wit-workspace and wit-manifest in
+    # packages
+    @staticmethod
+    def read_manifest(wsroot, path):
+        content = json.loads(path.read_text())
+        return Manifest.process_manifest(wsroot, content)
+
+    @staticmethod
+    def process_manifest(wsroot, json_content):
+        packages = [Package.from_manifest(wsroot, x) for x in json_content]
+        return Manifest(packages)
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/package.py
+++ b/package.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import subprocess
+import argparse
+import gitrepo
+
+# Make this a factory for different VCS types
+class Package:
+    """
+    Generic package type
+    """
+
+    @staticmethod
+    def from_arg(s):
+        """
+        >>> Package.from_arg(".::HEAD")
+        gitrepo.GitRepo(source='.', revision='HEAD')
+        >>> Package.from_arg("not-a-repo")
+        Traceback (most recent call last):
+            ...
+        argparse.ArgumentTypeError: Remote git repo 'not-a-repo' does not exist!
+        """
+        # TODO Could speed up valiation
+        #   - use git ls-remote to validate remote exists
+        #   - use git ls-remote to validate revision for tags and branches
+        #   - if github repo, check if page exists (or if you get 404)
+        # FIXME: This is ugly. Split on '::' into a path and revision, but
+        # there may not be a revision. So add an additional array
+        source, rev = (s.split("::") + [None])[:2]
+        if rev == None:
+            rev = "HEAD"
+        if not gitrepo.GitRepo.is_git_repo(source):
+            msg = "Remote git repo '{}' does not exist!".format(source)
+            raise argparse.ArgumentTypeError(msg)
+
+        return gitrepo.GitRepo(source, rev)
+
+    @staticmethod
+    def from_manifest(wsroot, m):
+        commit = m['commit']
+        name = m['name']
+        source = m['source']
+        path = wsroot / name
+        #if not gitrepo.GitRepo.is_git_repo(path):
+        #    # TODO implement redownloading from remote
+        #    msg = "path '{}' is not a git repo even though it's in the manifest!".format(path)
+        #    raise Exception(msg)
+
+        return gitrepo.GitRepo(source=source, revision=commit, name=name, path=path)
+
+
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/t/regress.sh
+++ b/t/regress.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ## List of tests to ignore
 test_ignore_list=( test_fail )

--- a/t/wit_init.t
+++ b/t/wit_init.t
@@ -2,13 +2,13 @@
 
 . $(dirname $0)/regress_util.sh
 
-wit init 
+wit init
 check "Wit init with no arguments should fail" [ $? -eq 2 ]
 
 echo "Verify that we can create a workspace with no initial repo"
 wit init myws
 check "Wit init with no initial repo succeeds" [ $? -eq 0 ]
-check "Wit creates a wit-manifest.json file" [ -e 'myws/wit-manifest.json' ]
+check "Wit creates a wit-workspace.json file" [ -e 'myws/wit-workspace.json' ]
 
 report
 finish

--- a/t/wit_init_add.t
+++ b/t/wit_init_add.t
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+. $(dirname $0)/regress_util.sh
+
+# This is an arbitrary hash from the wit repo
+hash=e8e3572be10994a140f0086abc7a0533272832eb
+echo "Verify that we can create a workspace with no initial repo"
+wit init myws -a ${wit_repo}::${hash}
+
+# Extract the wit hash recorded in the wit-workspace
+cd myws
+wit_workspace_hash=$(jq -r '.[] | select(.name=="wit") | .commit' wit-workspace.json)
+check "Wit manifest contains requested hash" [ "$wit_workspace_hash" = "$hash" ]
+
+# Get the latest checked out version of the wit repo and make
+# sure it matches what we expect
+wit update
+git_repo_hash=$(git --git-dir=wit/.git rev-parse HEAD)
+check "Updated wit repo is at requested hash" [ "$git_repo_hash" = "$hash" ]
+
+report
+finish

--- a/t/wit_update.t
+++ b/t/wit_update.t
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+. $(dirname $0)/regress_util.sh
+
+# Set up repo foo
+mkdir foo
+git -C foo init
+touch foo/file
+git -C foo add -A
+git -C foo commit -m "commit1"
+foo_commit=$(git -C foo rev-parse HEAD)
+
+# Now set up repo bar to depend on foo
+mkdir bar
+git -C bar init
+echo "[{\"commit\":\"$foo_commit\",\"name\":\"foo\",\"source\":\"$PWD/foo\"}]" | jq '.' >> bar/wit-manifest.json
+git -C bar add -A
+git -C bar commit -m "commit1"
+bar_commit=$(git -C bar rev-parse HEAD)
+
+# Now create a workspace from bar
+wit init myws -a $PWD/bar
+
+cd myws
+wit update
+
+check "foo should be pulled in as a dependency of bar" [ -d foo ]
+foo_ws_commit=$(git -C foo rev-parse HEAD)
+check "foo commit should match the dependency in bar" [ "$foo_ws_commit" = "$foo_commit" ]
+
+foo_lock_commit=$(jq -r '.foo.commit' wit-lock.json)
+check "ws-lock.json should contain correct foo commit" [ "$foo_lock_commit" = "$foo_commit" ]
+
+bar_lock_commit=$(jq -r '.bar.commit' wit-lock.json)
+check "ws-lock.json should contain correct bar commit" [ "$bar_lock_commit" = "$bar_commit" ]
+
+report
+finish

--- a/wit
+++ b/wit
@@ -10,13 +10,15 @@
 # * Use a real logger
 # * Handle partial sha1s correctly
 
- 
+
 import argparse
-from workspace import WorkSpace, GitRepo
+from workspace import WorkSpace
+from package import Package
 import logging
 import os
 import sys
 from collections import OrderedDict
+from pathlib import Path
 
 logging.basicConfig(level = logging.INFO)
 log = logging.getLogger('wit')
@@ -31,11 +33,11 @@ def main() -> None:
     subparsers = parser.add_subparsers(dest='command', help='sub-command help')
 
     init_parser = subparsers.add_parser('init', help='create workspace')
-    init_parser.add_argument('-a', '--add', metavar='repo', help='add an initial repo')
+    init_parser.add_argument('-a', '--add', metavar='repo[::revision]', action='append', type=Package.from_arg, help='add an initial repo')
     init_parser.add_argument('workspace_name')
 
     add_parser = subparsers.add_parser('add', help='add repo to workspace')
-    add_parser.add_argument('repo_name')
+    add_parser.add_argument('repo', metavar='repo[::revision]', type=Package.from_arg)
 
     subparsers.add_parser('status', help='show status of workspace')
     subparsers.add_parser('update', help='update git repos')
@@ -44,28 +46,28 @@ def main() -> None:
 
     if args.verbose:
         log.setLevel(logging.WARNING)
-        
+
     elif args.debug:
         log.setLevel(logging.DEBUG)
 
     else:
         log.setLevel(logging.INFO)
 
-    ws = WorkSpace(args.repomap)
+    #ws = WorkSpace(args.repomap)
     # FIXME: This big switch statement... no good.
     if args.command == 'init':
-        create(ws, args)
+        create(args)
 
     else:
         # These commands assume the workspace already exists. Error out if the
         # workspace cannot be found.
         try:
-            ws.find()
-            
+            ws = WorkSpace.find(Path.cwd())
+
         except FileNotFoundError as e:
             log.error("Unable to find workspace root [{}]. Cannot continue.".format(e))
             sys.exit(1)
-            
+
         if args.command == 'add':
             add(ws, args)
 
@@ -76,19 +78,18 @@ def main() -> None:
             update(ws, args)
 
 
-def create(ws, args):
+def create(args):
     log.info("Creating workspace [{}]".format(args.workspace_name))
 
-    ws.create(args.workspace_name)
-    if args.add is not None:
-        source, revision = split_repo_rev(args.add)
-        ws.add_repo(source=source, revision=revision)
-
+    if args.add is None:
+        packages = []
+    else:
+        packages = args.add
+    WorkSpace.create(args.workspace_name, packages)
 
 def add(ws, args):
     log.info("Adding repo to workspace")
-    source, revision = split_repo_rev(args.repo_name)
-    ws.add_repo(source=source, revision=revision)
+    ws.add_package(args.repo)
 
 
 def status(ws, args):
@@ -98,34 +99,33 @@ def status(ws, args):
         return
 
     clean = []
-    dirty = OrderedDict()
-    for reponame in ws.lock:
+    dirty = []
+    for package in ws.lock.packages:
         # FIXME: cheating by diving into the object.
-        manifest_commit = ws.lock[reponame]['commit']
-        repo = GitRepo.create(ws.lock[reponame]['source'], dest=ws.path)
-        latest_commit = repo.get_latest_commit()
+        lock_commit = package.revision
+        latest_commit = package.get_latest_commit()
 
-        new_commits = manifest_commit != latest_commit
+        new_commits = lock_commit != latest_commit
 
-        if new_commits or not repo.clean():
+        if new_commits or not package.clean():
             status = []
             if new_commits:
                 status.append("new commits")
-            if repo.modified():
+            if package.modified():
                 status.append("modified content")
-            if repo.untracked():
+            if package.untracked():
                 status.append("untracked content")
-            dirty[reponame] = status
+            dirty.append((package, status))
         else:
-            clean.append(reponame)
+            clean.append(package)
 
-    print("Clean repos:")
-    for repo in clean:
-        print("    {}".format(repo))
+    print("Clean packages:")
+    for package in clean:
+        print("    {}".format(package.name))
     print("Dirty repos:")
-    for repo, content in dirty.items():
+    for package, content in dirty:
         msg = ", ".join(content)
-        print("    {} ({})".format(repo, msg))
+        print("    {} ({})".format(package.name, msg))
 
 
 def update(ws, args):
@@ -133,12 +133,6 @@ def update(ws, args):
     ws.update()
 
 
-def split_repo_rev(repo_string):
-    # FIXME: This is ugly. Split on '::' into a path and revision, but
-    # there may not be a revision. So add an additional array
-    source, rev = (repo_string.split("::") + [None])[:2]
-    return source, rev
-
-
 if __name__ == '__main__':
     main()
+

--- a/workspace.py
+++ b/workspace.py
@@ -8,6 +8,10 @@ from pprint import pformat
 import logging
 import subprocess
 from collections import OrderedDict
+from gitrepo import GitRepo
+from manifest import Manifest
+from package import Package
+from lock import LockFile
 
 logging.basicConfig()
 log = logging.getLogger('wit')
@@ -16,89 +20,102 @@ log = logging.getLogger('wit')
 class NotAncestorError(Exception):
     pass
 
-
 class RepoAgeConflict(Exception):
     pass
 
-
-class GitError(Exception):
-    pass
-
-    
 class WorkSpace:
-    MANIFEST = "wit-manifest.json"
+    MANIFEST = "wit-workspace.json"
     LOCK = "wit-lock.json"
 
-    def __init__(self, repomap):
-        self.path = None
-        self.manifest = []
-        self.lock = OrderedDict()
-
-        if repomap is not None:
-            self.repomap = self.read_repomap(repomap)
-
-        else:
-            self.repomap = None
-    
+    def __init__(self, path, manifest, lock=None):
+        self.path = path
+        self.manifest = manifest
+        self.lock = lock
 
     # create a new workspace root given a name.
-    def create(self, name):
-        self.path = Path.cwd() / name
+    @staticmethod
+    def create(name, packages):
+        path = Path.cwd() / name
 
-        if self.path.exists():
-            log.info("Using existing directory [{}]".format(str(self.path)))
+        manifest_path = WorkSpace._manifest_path(path)
+        if path.exists():
+            log.info("Using existing directory [{}]".format(str(path)))
 
-            manifest_file = self.path / self.MANIFEST
-            if manifest_file.exists():
-                log.error("Manifest file [{}] already exists.".format(manifest_file))
+            if manifest_path.exists():
+                log.error("Manifest file [{}] already exists.".format(manifest_path))
                 sys.exit(1)
 
         else:
-            log.info("Creating new workspace [{}]".format(str(self.path)))
+            log.info("Creating new workspace [{}]".format(str(path)))
             try:
-                self.path.mkdir()
+                path.mkdir()
 
             except Exception as e:
-                log.error("Unable to create workspace [{}]: {}".format(str(self.path), e))
+                log.error("Unable to create workspace [{}]: {}".format(str(path), e))
                 sys.exit(1)
 
-        self.path = self.path.resolve()
-        self.write_manifest()
+        for package in packages:
+            package.set_path(path)
+            package.clone_and_checkout()
+        manifest = Manifest(packages)
+        manifest.write(manifest_path)
+        return WorkSpace(path, manifest)
 
+    # FIXME It's a little weird that we have these special classmethod ones
+    # They're here to calculate the paths in staticmethods
+    @classmethod
+    def _manifest_path(cls, path):
+        return path / cls.MANIFEST
+
+    def manifest_path(self):
+        return WorkSpace._manifest_path(self.path)
+
+    @classmethod
+    def _lockfile_path(cls, path):
+        return path / cls.LOCK
+
+    def lockfile_path(self):
+        return WorkSpace._lockfile_path(self.path)
 
     # find a workspace root by iteratively walking up the path
     # until a manifest file is found.
-    def find(self):
-        cwd = Path.cwd().resolve()
+    @staticmethod
+    def find(start):
+        cwd = start.resolve()
         for p in ([cwd] + list(cwd.parents)):
-            log.info("Checking [{}]".format(p / self.MANIFEST))
-            if Path(p / self.MANIFEST).is_file():
+            manifest_path = WorkSpace._manifest_path(p)
+            log.info("Checking [{}]".format(manifest_path))
+            if Path(manifest_path).is_file():
                 log.debug("Found workspace at [{}]".format(p))
-                self.path = p
+                wspath = p
+                manifest = Manifest.read_manifest(wspath, manifest_path)
 
-                self.read_manifest()
-                if Path(self.lockfile_path()).is_file():
-                    self.read_lockfile()
-                return
-        
+                lockfile_path = WorkSpace._lockfile_path(p)
+                if lockfile_path.is_file():
+                    lock = LockFile.read(lockfile_path)
+                else:
+                    lock = None
+
+                return WorkSpace(wspath, manifest, lock=lock)
+
         raise FileNotFoundError("Couldn't find manifest file")
 
 
+    # FIXME Should we run this algorithm upon `wit status` to mention if lockfile out of sync?
     def update(self):
         # This algorithm courtesy of Wes
         # https://sifive.atlassian.net/browse/FRAM-1
         # 1. Initialize an empty version selector map
         version_selector_map = {}
-        self.lock = OrderedDict()
 
         # 2. For every existing repo put a tuple (name, hash, commit time) into queue
         queue = []
-        for ws in self.manifest:
-            repo = GitRepo.create(ws['source'], dest=self.path)
-            commit_time = repo.commit_to_time(ws['commit'])
+        for repo in self.manifest.packages:
+            commit = repo.revision
+            commit_time = repo.commit_to_time(commit)
 
-            queue.append((commit_time, ws['commit'], ws['name'], repo))
-        
+            queue.append((commit_time, commit, repo.name, repo))
+
         # sort by the first element of the tuple (commit time in epoch seconds)
         queue.sort(key=lambda tup: tup[0])
         log.debug(queue)
@@ -109,7 +126,7 @@ class WorkSpace:
             commit_time, commit, reponame, repo = queue.pop()
             if reponame in version_selector_map:
                 selected_commit = version_selector_map[reponame]['commit']
-                
+
                 # 4. If the repo has a selected version, fail if that version
                 # does not include this tuple's hash
                 if not repo.is_ancestor(commit, selected_commit):
@@ -128,19 +145,20 @@ class WorkSpace:
             }
 
             # 7. Examine the repository's children
-            dependencies = repo.get_dependencies(hash=commit)            
-            log.debug("Dependencies for [{}]: [{}]".format(repo.clone_path, dependencies))
+            dependencies = repo.get_dependencies(self.path)
+            log.debug("Dependencies for [{}]: [{}]".format(repo.path, dependencies))
 
-            for dependent in dependencies:
+            for dep_repo in dependencies:
                 # Check to see if there is a path specified in the repomap.
                 # If so, use that path instead.
-                dependent['source'] = self.resolve_repomap(dependent['source'])
+                #dependent['source'] = self.resolve_repomap(dependent['source'])
 
                 # 8. Clone without checking out the dependency
-                dep_repo = GitRepo.create(source=dependent['source'], dest=self.path)
-                
+                if not GitRepo.is_git_repo(dep_repo.path):
+                    dep_repo.clone()
+
                 # 9. Find the committer date
-                dep_commit_time = dep_repo.commit_to_time(dependent['commit'])
+                dep_commit_time = dep_repo.commit_to_time(dep_repo.revision)
 
                 # 10. Fail if the dependent commit date is newer than the parent date
                 if dep_commit_time > commit_time:
@@ -148,10 +166,11 @@ class WorkSpace:
                     raise RepoAgeConflict
 
                 # 11. Push a tuple onto the queue
-                queue.append((dep_commit_time, dependent['commit'], dep_repo.name, dep_repo))
-        
+                queue.append((dep_commit_time, dep_repo.revision, dep_repo.name, dep_repo))
+
             # Keep the queue ordered
             queue.sort(key = lambda tup: tup[0])
+
 
             # 12. Go to step 3 (finish loop)
 
@@ -161,217 +180,42 @@ class WorkSpace:
             print("Repo name [{}] commit [{}]".format(reponame, commit))
 
         # 14. Check out repos and add to lock
+        lock_packages = []
         for reponame in version_selector_map:
             commit = version_selector_map[reponame]['commit']
             repo = version_selector_map[reponame]['repo']
-            repo.checkout(commit)
-            self.lock[reponame] = repo.manifest()
-            self.write_lockfile()
+            lock_repo = GitRepo(repo.source, commit, name=repo.name, path=repo.path)
+            lock_repo.checkout()
+            lock_packages.append(lock_repo)
+
+        # TODO compare to current and print info?
+        new_lock = LockFile(lock_packages)
+        new_lock.write(self.lockfile_path())
+        self.lock = new_lock
 
 
-    def manifest_path(self):
-        return self.path / self.MANIFEST
+    def add_package(self, package):
+        #source = self.resolve_repomap(source)
+        package.set_path(self.path)
 
+        if GitRepo.is_git_repo(package.path):
+            raise NotImplementedError
+        else:
+            package.clone_and_checkout()
 
-    def lockfile_path(self):
-        return self.path / self.LOCK
-        
-        
-    def write_lockfile(self):
-        lockfile_json = json.dumps(self.lock, sort_keys=True, indent=4) + '\n'
-        self.lockfile_path().write_text(lockfile_json)
+        if self.manifest.contains_package(package):
+            # TODO Update the revision
+            raise NotImplementedError
+        else:
+            log.info("Adding [{}] to manifest as [{}]".format(package.source, package.name))
+            self.manifest.add_package(package)
 
-    def read_lockfile(self):
-        lockfile_json = self.lockfile_path().read_text()
-        self.lock = json.loads(lockfile_json, object_pairs_hook=OrderedDict)
-
-    def write_manifest(self):
-        manifest_json = json.dumps(self.manifest, sort_keys=True, indent=4) + '\n'
-        self.manifest_path().write_text(manifest_json)
-            
-
-    def read_manifest(self):
-        manifest_json = self.manifest_path().read_text()
-        self.manifest = json.loads(manifest_json)
-
-
-    # FIXME: Too much going on here, and this couples WorkSpace too closely
-    # with git repos. Need to move manifest generation into GitRepo, and allow
-    # for instantiating other repo types here
-    def add_repo(self, source=None, revision=None):
-        source = self.resolve_repomap(source)
-
-        repo = GitRepo.create(source, dest=self.path)
-        repo.checkout(revision or repo.get_latest_commit())
-        if repo.name not in self.manifest:
-            self.manifest.append(repo.manifest())
-            print("Adding [{}] to manifest as [{}]".format(source, repo.name))
-
-        self.write_manifest()
+        print('my manifest_path = {}'.format(self.manifest_path()))
+        self.manifest.write(self.manifest_path())
 
 
     def repo_status(self, source):
-        raise NotImplementedError   
-
-
-    @staticmethod
-    def read_repomap(repomap):
-        repomap_path = Path(repomap)
-        try:
-            repomap_json = repomap_path.read_text()
-            data = json.loads(repomap_json)
-        except Exception as e:
-            log.error("Unable to read repomap [{}] for reading: {}".format(repomap_path, e))
-            sys.exit(1)
-
-        return data
-
-
-    def resolve_repomap(self, path):
-        if self.repomap and path in self.repomap:
-            log.info("Mapped repo [{}] to [{}] using repomap.".format(path, self.repomap[path]))
-            path = self.repomap[path]
-        
-        return path
-
-
-    # Enable prettyish-printing of the class
-    def __repr__(self):
-        return pformat(vars(self), indent=4, width=1)
-
-
-# Make this a factory for different VCS types
-class Package:
-    pass
-
-
-class GitRepo:
-    WIT_DEPENDENCY_FILE = "wit-manifest.json"
-    instance_map = {}
-
-    def __init__(self, source):
-        self.source = source
-        self.name = GitRepo.path_to_name(source)
-        GitRepo.instance_map[source] = self
-
-
-    # Instantiate a git object and, if not already done, create a clone
-    @classmethod
-    def create(cls, source, dest=None, commit=None):
-        if source in cls.instance_map:
-            self = cls.instance_map[source]
-        else:
-            self = cls(source)
-
-        # We're already in the root of the workspace, so this will put the
-        # clone directly at the top level of the workspace
-        self.clone_path = dest / self.name
-        if not self.clone_path.is_dir():
-            os.mkdir(str(self.clone_path))
-            proc = self._git_command("clone", "--no-checkout", str(self.source), str(self.clone_path))
-            
-            try:
-                self._git_check(proc)
-            except Exception as e:
-                log.error("Error cloning into workspace: {}".format(e))
-                sys.exit(1)
-
-        return self
-
-
-    def get_latest_commit(self):
-        proc = self._git_command('rev-parse', 'HEAD')
-        self._git_check(proc)
-        return proc.stdout.rstrip()
-
-    def clean(self):
-        proc = self._git_command('status', '--porcelain')
-        self._git_check(proc)
-        return proc.stdout == ""
-
-    def modified(self):
-        proc = self._git_command('status', '--porcelain')
-        self._git_check(proc)
-        for line in proc.stdout.split("\n"):
-            if line.lstrip().startswith("M"):
-                return True
-        return False
-
-    def untracked(self):
-        proc = self._git_command('status', '--porcelain')
-        self._git_check(proc)
-        for line in proc.stdout.split("\n"):
-            if line.lstrip().startswith("??"):
-                return True
-        return False
-
-
-    def commit_to_time(self, hash):
-        proc = self._git_command('log', '-n1', '--format=%ct', hash)
-        self._git_check(proc)
-
-        return proc.stdout.rstrip()
-    
-
-    def is_ancestor(self, ancestor, current=None):
-        proc = self._git_command("merge-base", "--is-ancestor", ancestor, current or self.get_latest_commit())
-        if proc.returncode != 0:
-            return False
-
-        else:
-            return True
-
-
-    def get_dependencies(self, hash=None):
-        proc = self._git_command("show", "{}:{}".format(hash, GitRepo.WIT_DEPENDENCY_FILE))
-        if proc.returncode:
-            log.info("No dependency file found in repo [{}:{}]".format(hash, self.clone_path))
-            return []
-
-        return json.loads(proc.stdout)
-        
-    
-    def checkout(self, hash):
-        proc = self._git_command("checkout", hash)
-        self._git_check(proc)
-
-    
-    def manifest(self):
-        return {
-            'name': self.name,
-            'source': self.source,
-            'commit': str(self.get_latest_commit()),
-        }
-
-
-    def _git_command(self, *args):
-        log.debug("Executing [{}] in [{}]".format(' '.join(['git', *args]), self.clone_path))
-        proc = subprocess.run(['git', *args], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            cwd=str(self.clone_path), universal_newlines=True)
-        return proc
-
-
-    def _git_check(self, proc):
-        if proc.returncode:
-            log.error("Command [{}] exited with non-zero exit status [{}]".format(' '.join(proc.args), proc.returncode))
-            log.error("stdout: [{}]".format(proc.stdout.rstrip()))
-            log.error("stderr: [{}]".format(proc.stderr.rstrip()))
-            raise GitError(proc.stderr.rstrip())
-
-        return proc.returncode
-
-
-    @staticmethod
-    def path_to_name(path):
-        """
-        >>> GitRepo.path_to_name("a.git")
-        'a'
-        >>> GitRepo.path_to_name("/a/b/c/def.git")
-        'def'
-        >>> GitRepo.path_to_name("ghi")
-        'ghi'
-        """
-        return Path(path).name.replace('.git', '')
+        raise NotImplementedError
 
 
     # Enable prettyish-printing of the class


### PR DESCRIPTION
Improve error reporting for adding a repo during init
Rename top of workspace from wit-manifest.json to wit-workspace.json
Add Manifest class wit-manifest.json and wit-workspace.json
Add LockFile class for wit-lock.json
Add Package class as factory for packages, currently just git repos

Not really any functionality changes yet, but some work separating a few concerns