### PR TITLE
Extend add-pkg to work on already cloned repos

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import logging
+import sys
+
+log = logging.getLogger('wit')
+
+
+def error(*args, **kwargs):
+    log.error(*args, **kwargs)
+    sys.exit(1)

--- a/lib/gitrepo.py
+++ b/lib/gitrepo.py
@@ -74,11 +74,15 @@ class GitRepo:
     def clone_and_checkout(self):
         self.clone()
         self.checkout()
-        # If our revision was a branch or tag, get the actual commit
-        self.revision = self.get_latest_commit()
 
     def get_latest_commit(self):
         proc = self._git_command('rev-parse', 'HEAD')
+        self._git_check(proc)
+        return proc.stdout.rstrip()
+
+    def get_remote(self) -> str:
+        # TODO Do we need to worry about other remotes?
+        proc = self._git_command('remote', 'get-url', 'origin')
         self._git_check(proc)
         return proc.stdout.rstrip()
 
@@ -132,6 +136,8 @@ class GitRepo:
     def checkout(self):
         proc = self._git_command("checkout", self.revision)
         self._git_check(proc)
+        # If our revision was a branch or tag, get the actual commit
+        self.revision = self.get_latest_commit()
 
     def manifest_path(self):
         return self.get_path() / self.PKG_DEPENDENCY_FILE

--- a/t/wit_add_pkg_already_cloned.t
+++ b/t/wit_add_pkg_already_cloned.t
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+. $(dirname $0)/regress_util.sh
+
+# Set up repo foo
+make_repo 'foo'
+foo_commit=$(git -C foo rev-parse HEAD)
+foo_dir=$PWD/foo
+
+set -x
+# Now create an empty workspace
+wit init myws
+
+cd myws
+git clone $foo_dir
+
+wit add-pkg $foo_dir
+check "wit add-pkg an already cloned repo should succeed" [ $? -eq 0 ]
+
+foo_ws_commit=$(jq -r '.[] | select(.name=="foo") | .commit' wit-workspace.json)
+check "Added repo should have correct commit" [ "$foo_ws_commit" = "$foo_commit" ]
+
+foo_ws_source=$(jq -r '.[] | select(.name=="foo") | .source' wit-workspace.json)
+check "Added repo should have source copied from remote" [ "$foo_ws_source" = "$foo_dir" ]
+
+set +x
+
+report
+finish

--- a/t/wit_add_pkg_exists.t
+++ b/t/wit_add_pkg_exists.t
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+. $(dirname $0)/regress_util.sh
+
+# Set up repo foo
+make_repo 'foo'
+foo_commit=$(git -C foo rev-parse HEAD)
+foo_dir=$PWD/foo
+
+set -x
+# Now create an empty workspace
+wit init myws
+
+cd myws
+wit add-pkg $foo_dir
+check "wit add-pkg should succeed" [ $? -eq 0 ]
+
+wit add-pkg $foo_dir
+check "wit add-pkg a second time should fail" [ $? -eq 1 ]
+
+set +x
+
+report
+finish


### PR DESCRIPTION
Open question is what should happen if you `add-pkg` something that is not in the manifest, but is in the lock. Currently it just succeeds, I suspect it should print some type of info.