### PR TITLE
Scala plugin fetch groups

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -213,7 +213,7 @@ def fetch_scala(ws, args, agg=True) -> None:
     # Collect ivydependency files
     files = []
     for package in ws.lock.packages:
-        ivyfile = scalaplugin.ivy_deps_file(package)
+        ivyfile = scalaplugin.ivy_deps_file(package.get_path())
         if os.path.isfile(ivyfile):
             files.append(ivyfile)
         else:
@@ -229,9 +229,9 @@ def fetch_scala(ws, args, agg=True) -> None:
     else:
         log.info("Fetching Scala install and dependencies...")
 
-        install_dir = scalaplugin.scala_install_dir(ws)
+        install_dir = scalaplugin.scala_install_dir(ws.path)
 
-        ivy_cache_dir = scalaplugin.ivy_cache_dir(ws)
+        ivy_cache_dir = scalaplugin.ivy_cache_dir(ws.path)
         os.makedirs(ivy_cache_dir, exist_ok=True)
 
         # Check if we need to install Bloop
@@ -241,7 +241,7 @@ def fetch_scala(ws, args, agg=True) -> None:
         else:
             log.info("Installing Scala to {}...".format(install_dir))
             os.makedirs(install_dir, exist_ok=True)
-            scalaplugin.install_bloop(install_dir, ivy_cache_dir)
+            scalaplugin.install_coursier(install_dir, ivy_cache_dir)
 
         log.info("Fetching ivy dependencies...")
         scalaplugin.fetch_ivy_dependencies(files, install_dir, ivy_cache_dir)

--- a/t/scala_plugin.t
+++ b/t/scala_plugin.t
@@ -34,16 +34,19 @@ jar="json4s-native_2.12-3.6.1.jar"
 found=$(find . -name "$jar")
 check "We should find $jar" [ ! -z "$found" ]
 
-bloop_bin="scala/bloop"
-check "$bloop_bin should exist" [ -f "$bloop_bin" ]
-
-coursier_bin="scala/blp-coursier"
+coursier_bin="scala/coursier"
 check "$coursier_bin should exist" [ -f "$coursier_bin" ]
 
 # This one is implicit in the Scala Version
 scala_jar="scala-compiler-2.12.8.jar"
 found_scala=$(find . -name "$scala_jar")
 check "We should also find Scala" [ ! -z $found_scala ]
+
+# Because we fetch Scala Version together with the dependencies, we get Scala
+# 2.12.8 but not 2.12.6 (which is the one json4s directly depends on)
+bad_scala_jar="scala-library-2.12.6.jar"
+not_found_scala=$(find . -name "$bad_scala_jar")
+check "We should not find the wrong Scala" [ -z $not_found_scala ]
 
 report
 finish


### PR DESCRIPTION
This changes the behavior of dependency fetching for the Scala plugin. It now fetches less by resolving things in groups of dependencies. This is important because sometimes one dependency may bump the version of something depended on by something else. In particular, from the revised `scala_plugin.t`:

```json
{
    "foo": {
      "scalaVersion": "2.12.8",
      "dependencies": [
          "org.json4s::json4s-native:3.6.1",
          "org.antlr:antlr4:4.7.2"
      ]
    }
}
```

`org.json4s:json4s-native_2.12:3.6.1` depends on Scala `2.12.6`, so before we would also fetch that version of Scala, this is unnecessary since we're running with Scala `2.12.8`. Now we only fetch the appropriate amount. This also no longer fetches bloop directly, but rather fetches `coursier`. The scala-wake rules then depend on bloop as an ivydependency, so it is fetched that way.