### PR TITLE
Improve add-dep to clone remote packages and determine commit hash

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -9,3 +9,10 @@ log = logging.getLogger('wit')
 def error(*args, **kwargs):
     log.error(*args, **kwargs)
     sys.exit(1)
+
+
+class WitUserError(Exception):
+    """
+    Supertype of user-input errors that should be reported without stack traces
+    """
+    pass

--- a/lib/gitrepo.py
+++ b/lib/gitrepo.py
@@ -76,7 +76,10 @@ class GitRepo:
         self.checkout()
 
     def get_latest_commit(self):
-        proc = self._git_command('rev-parse', 'HEAD')
+        return self.get_commit('HEAD')
+
+    def get_commit(self, commit):
+        proc = self._git_command('rev-parse', commit)
         self._git_check(proc)
         return proc.stdout.rstrip()
 
@@ -130,8 +133,11 @@ class GitRepo:
         return lib.manifest.Manifest.process_manifest(wsroot, json_content).packages
 
     def add_dependency(self, package):
+        log.info("Adding dependency to '{}' on '{}' at '{}'".format(
+                  self.name, package.name, package.revision))
         path = self.manifest_path()
-        lib.manifest.Manifest.read(path, safe=True).add_package(package).write(path)
+        manifest = lib.manifest.Manifest.read_manifest(self.wsroot, path, safe=True)
+        manifest.add_package(package).write(path)
 
     def checkout(self):
         proc = self._git_command("checkout", self.revision)

--- a/lib/lock.py
+++ b/lib/lock.py
@@ -2,8 +2,10 @@
 
 import json
 from lib.package import Package
+from lib.gitrepo import GitRepo
 from collections import OrderedDict
 import logging
+from typing import Optional
 
 log = logging.getLogger('wit')
 
@@ -19,11 +21,14 @@ class LockFile:
     def __init__(self, packages=[]):
         self.packages = packages
 
-    def contains_package(self, package):
+    def get_package(self, name: str) -> Optional[GitRepo]:
         for p in self.packages:
-            if p.name == package.name:
-                return True
-        return False
+            if p.name == name:
+                return p
+        return None
+
+    def contains_package(self, name: str) -> bool:
+        return self.get_package(name) is not None
 
     def add_package(self, package):
         self.packages.append(package)

--- a/lib/manifest.py
+++ b/lib/manifest.py
@@ -31,19 +31,13 @@ class Manifest:
         manifest_json = json.dumps(contents, sort_keys=True, indent=4) + '\n'
         path.write_text(manifest_json)
 
-    @staticmethod
-    def read(path, safe=False):
-        if safe and not Path(path).exists():
-            return Manifest([])
-
-        content = json.loads(path.read_text())
-        return Manifest(content)
-
     # FIXME It's maybe a little weird that we need wsroot but that's because
     # this method is being used for both wit-workspace and wit-manifest in
     # packages
     @staticmethod
-    def read_manifest(wsroot, path):
+    def read_manifest(wsroot, path, safe=False):
+        if safe and not Path(path).exists():
+            return Manifest([])
         content = json.loads(path.read_text())
         return Manifest.process_manifest(wsroot, content)
 

--- a/lib/workspace.py
+++ b/lib/workspace.py
@@ -8,7 +8,7 @@ from lib.gitrepo import GitRepo
 from lib.manifest import Manifest
 from lib.lock import LockFile
 from lib.package import Package
-from typing import List
+from typing import List, Optional
 from lib.common import error
 
 log = logging.getLogger('wit')
@@ -235,6 +235,9 @@ class WorkSpace:
 
         log.debug('my manifest_path = {}'.format(self.manifest_path()))
         self.manifest.write(self.manifest_path())
+
+    def get_package(self, name: str) -> Optional[GitRepo]:
+        return self.lock.get_package(name)
 
     def update_package(self, package):
         raise NotImplementedError

--- a/t/wit_add_dep_already_cloned.t
+++ b/t/wit_add_dep_already_cloned.t
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+. $(dirname $0)/regress_util.sh
+
+# Set up repo foo
+make_repo 'foo'
+foo_commit=$(git -C foo rev-parse HEAD)
+foo_dir=$PWD/foo
+
+make_repo 'bar'
+bar_commit=$(git -C bar rev-parse HEAD)
+bar_dir=$PWD/bar
+
+set -x
+# Now create an empty workspace
+wit init myws -a $foo_dir
+
+cd myws
+git clone $bar_dir
+
+wit -C foo add-dep bar
+check "wit add-dep an already cloned repo should succeed" [ $? -eq 0 ]
+
+bar_manifest_commit=$(jq -r '.[] | select(.name=="bar") | .commit' foo/wit-manifest.json)
+check "Added bar dependency should have correct commit" [ "$bar_manifest_commit" = "$bar_commit" ]
+
+set +x
+
+report
+finish

--- a/t/wit_add_dep_not_repo.t
+++ b/t/wit_add_dep_not_repo.t
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+. $(dirname $0)/regress_util.sh
+
+prereq on
+
+# Set up repo foo
+mkdir foo
+git -C foo init
+touch foo/file
+git -C foo add -A
+git -C foo commit -m "commit1"
+foo_dir=$PWD/foo
+
+# Now create an empty workspace
+wit init myws
+cd myws
+
+# Make some random directory
+mkdir bar
+
+# Make a repo that's not part of the workspace
+make_repo 'fizz'
+
+prereq off
+
+set -x
+
+# Now try to make bar depend on foo
+msg=$(wit -C bar add-dep $foo_dir)
+check "Adding dependency to non-package should fail" [ $? -ne 0 ]
+
+msg=$(wit -C fizz add-dep $foo_dir)
+check "Adding dependency to non-workspace repo should fail" [ $? -ne 0 ]
+
+set +x
+
+report
+finish


### PR DESCRIPTION
This also adds `WitUserError` to try to provide better error messages (no stack traces on user error).

`wit add-dep` previously wouldn't fill in commit hash. Now it will. It also will fetch packages if they're not already checked out.