### PR TITLE
[Bugfix] Fix add-dep to clone source and not checkout existing repo

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -173,11 +173,13 @@ def add_dep(ws, args) -> None:
         if GitRepo.is_git_repo(dep.get_path()):
             log.debug("Repo '{}' already exists, skipping clone...".format(dep.name))
         else:
-            dep.clone()
-        dep.checkout()
+            dep.clone_and_checkout()
+        dep.source = dep.get_remote()
     else:
-        # Determine revision from existing package
+        # Determine revision and source from existing repo
         dep.revision = found.get_commit(dep.revision)
+        dep.source = found.get_remote()
+
     pkg.add_dependency(dep)
 
 

--- a/t/wit_add_dep.t
+++ b/t/wit_add_dep.t
@@ -27,7 +27,6 @@ git -C bar checkout master
 touch bar/file2
 git -C bar add -A
 git -C bar commit -m "commit2"
-bar_commit2=$(git -C bar rev-parse HEAD)
 bar_dir=$PWD/bar
 
 prereq off
@@ -52,6 +51,9 @@ check "wit add-dep should succeed" [ $? -eq 0 ]
 
 foo_bar_commit=$(jq -r '.[] | select(.name=="bar") | .commit' foo/wit-manifest.json)
 check "foo should depend on the correct commit of bar" [ "$foo_bar_commit" = "$bar_commit" ]
+
+bar_manifest_source=$(jq -r '.[] | select(.name=="bar") | .source' foo/wit-manifest.json)
+check "Added bar dependency should have correct source" [ "$bar_manifest_source" = "$bar_dir" ]
 
 check "bar should have been cloned when it was added as a dependency" [ -d bar/.git ]
 

--- a/t/wit_add_dep_already_cloned.t
+++ b/t/wit_add_dep_already_cloned.t
@@ -8,8 +8,12 @@ foo_commit=$(git -C foo rev-parse HEAD)
 foo_dir=$PWD/foo
 
 make_repo 'bar'
-bar_commit=$(git -C bar rev-parse HEAD)
 bar_dir=$PWD/bar
+bar_commit1=$(git -C bar rev-parse HEAD)
+echo "hi" > bar/file2
+git -C bar add -A
+git -C bar commit -m "commit2"
+bar_commit2=$(git -C bar rev-parse HEAD)
 
 set -x
 # Now create an empty workspace
@@ -18,11 +22,17 @@ wit init myws -a $foo_dir
 cd myws
 git clone $bar_dir
 
-wit -C foo add-dep bar
+wit -C foo add-dep bar::$bar_commit1
 check "wit add-dep an already cloned repo should succeed" [ $? -eq 0 ]
 
+bar_checkedout_commit=$(git -C bar rev-parse HEAD)
+check "wit should *not* do a checkout when adding dep on existing repo" [ "$bar_checkedout_commit" = "$bar_commit2" ]
+
 bar_manifest_commit=$(jq -r '.[] | select(.name=="bar") | .commit' foo/wit-manifest.json)
-check "Added bar dependency should have correct commit" [ "$bar_manifest_commit" = "$bar_commit" ]
+check "Added bar dependency should have correct commit" [ "$bar_manifest_commit" = "$bar_commit1" ]
+
+bar_manifest_source=$(jq -r '.[] | select(.name=="bar") | .source' foo/wit-manifest.json)
+check "Added bar dependency should have correct source" [ "$bar_manifest_source" = "$bar_dir" ]
 
 set +x
 

--- a/t/wit_add_dep_in_workspace.t
+++ b/t/wit_add_dep_in_workspace.t
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+. $(dirname $0)/regress_util.sh
+
+# Set up repo foo
+make_repo 'foo'
+foo_commit1=$(git -C foo rev-parse HEAD)
+foo_dir=$PWD/foo
+echo "wow" > foo/file2
+git -C foo add -A
+git -C foo commit -m "commit 2"
+foo_commit2=$(git -C foo rev-parse HEAD)
+
+make_repo 'bar'
+bar_dir=$PWD/bar
+cat << EOF | jq . > bar/wit-manifest.json
+[ {"commit": "$foo_commit1", "name": "foo", "source": "$foo_dir" } ]
+EOF
+git -C bar add -A
+git -C bar commit -m "Add dep on foo"
+bar_commit=$(git -C bar rev-parse HEAD)
+
+make_repo 'fizz'
+fizz_dir=$PWD/fizz
+cat << EOF | jq . > fizz/wit-manifest.json
+[ {"commit": "$bar_commit", "name": "bar", "source": "$bar_dir" } ]
+EOF
+git -C fizz add -A
+git -C fizz commit -m "Add dep on bar"
+
+set -x
+
+wit init myws -a $fizz_dir
+cd myws
+
+# Check out newer foo commit
+git -C foo checkout $foo_commit2
+
+wit -C fizz add-dep foo
+check "wit add-dep a package in the workspace should succeed" [ $? -eq 0 ]
+
+foo_manifest_commit=$(jq -r '.[] | select(.name=="foo") | .commit' fizz/wit-manifest.json)
+check "Added foo dependency should have correct commit" [ "$foo_manifest_commit" = "$foo_commit2" ]
+
+foo_manifest_source=$(jq -r '.[] | select(.name=="foo") | .source' fizz/wit-manifest.json)
+check "Added foo dependency should have correct source" [ "$foo_manifest_source" = "$foo_dir" ]
+
+set +x
+
+report
+finish


### PR DESCRIPTION
`add-dep` wasn't actually propagating remote/source in all cases, this fixes that and also fixes issue where if the dep being added was already cloned (but not part of the workspace), it would do a checkout which we should only do on `wit update`.

We could merge this before #58 and tag it `v0.7.1` since it's a bugfix