### PR TITLE
Use Coursier standalone instead of bootstrapping jar

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -286,7 +286,7 @@ def fetch_scala(ws, args, agg=True) -> None:
         else:
             log.info("Installing Scala to {}...".format(install_dir))
             os.makedirs(install_dir, exist_ok=True)
-            scalaplugin.install_coursier(install_dir, ivy_cache_dir)
+            scalaplugin.install_coursier(install_dir)
 
         log.info("Fetching ivy dependencies...")
         scalaplugin.fetch_ivy_dependencies(files, install_dir, ivy_cache_dir)

--- a/lib/scalaplugin.py
+++ b/lib/scalaplugin.py
@@ -26,9 +26,14 @@ def ivy_deps_file(package):
     return str(package / "ivydependencies.json")
 
 
-def install_coursier(install_dir, ivy_cache_dir):
+def install_coursier(install_dir):
+    version = "1.1.0-M14-6"
+    path = "io/get-coursier/coursier-cli_2.12/{}/coursier-cli_2.12-{}-standalone.jar".format(
+           version, version)
     filename = coursier_bin(install_dir)
-    urllib.request.urlretrieve('https://git.io/coursier-cli', filename)
+    url = "http://central.maven.org/maven2/{}".format(path)
+    print("Downloading from {}".format(url))
+    urllib.request.urlretrieve(url, filename)
     os.chmod(filename, 0o755)
 
 


### PR DESCRIPTION
Solution based on https://github.com/bazelbuild/rules_jvm_external/pull/88

The other url downloaded a bootstrapping jar for cousier that had some issues. This directly downloads the standalone jar from maven central which should fix the issues.

@maloneymr can you see if this fixes the issue in the Docker image that required `-j 1`?