### PR TITLE
warn when jq or java are missing

### DIFF
--- a/t/regress.sh
+++ b/t/regress.sh
@@ -67,6 +67,14 @@ echo "Results:"
 echo "Passing: $pass"
 echo "Failing: $fail"
 
+if ! [ -x "$(command -v jq)" ]; then
+    echo "Some tests may have failed due to jq not being found"
+fi
+
+if ! [ -x "$(command -v java)" ]; then
+    echo "Some tests may have failed due to java not being found"
+fi
+
 if [ $fail -ne 0 ]
 then exit 1
 else exit 0


### PR DESCRIPTION
Without this, a large number of tests will fail without indicating what needs to be fixed