### PR TITLE
fix typo in inspect.py

### DIFF
--- a/lib/inspect.py
+++ b/lib/inspect.py
@@ -88,7 +88,7 @@ def _recur_print_pkg_tree(depth, data, keys, idx, done_cols, already_explored):
     if this_already_explored:
         print(" (see above)")
     elif "->" in key:
-        superceded_key = key.split("@")[0]+"::"+key.split("->")[1]
+        superceded_key = key.split("@")[0]+"@"+key.split("->")[1]
         if superceded_key in already_explored:
             print(" (see above)")
         else:


### PR DESCRIPTION
I'll refactor `inspect.py`. I'd put this immediately in master but I didn't want to surprise anybody.