### PR TITLE
verify tags in add-pkg and add-dep

### DIFF
--- a/lib/wit/gitrepo.py
+++ b/lib/wit/gitrepo.py
@@ -114,6 +114,9 @@ class GitRepo:
         proc = self._git_command('cat-file', '-t', commit)
         return proc.returncode == 0
 
+    def roughly_has_rev(self, rev):
+        return self.has_commit(rev) or self.has_commit("origin/{}".format(rev))
+
     def get_remote(self) -> str:
         # TODO Do we need to worry about other remotes?
         proc = self._git_command('remote', 'get-url', 'origin')

--- a/lib/wit/main.py
+++ b/lib/wit/main.py
@@ -219,7 +219,7 @@ def add_dep(ws, args) -> None:
     req_dep.load_package(packages, ws.repo_paths)
     req_dep.package.load_repo(ws.root, download=True, needed_commit=req_dep.specified_revision)
 
-    if not req_dep.package.repo.has_commit(req_dep.specified_revision):
+    if not req_dep.package.repo.roughly_has_rev(req_dep.specified_revision):
         error("Cannot find commit '{}' in '{}'".format(req_dep.specified_revision, req_dep.name))
 
     req_dep.package.revision = req_dep.resolved_rev()

--- a/lib/wit/main.py
+++ b/lib/wit/main.py
@@ -218,6 +218,10 @@ def add_dep(ws, args) -> None:
     packages = {pkg.name: pkg for pkg in ws.lock.packages}
     req_dep.load_package(packages, ws.repo_paths)
     req_dep.package.load_repo(ws.root, download=True, needed_commit=req_dep.specified_revision)
+
+    if not req_dep.package.repo.has_commit(req_dep.specified_revision):
+        error("Cannot find commit '{}' in '{}'".format(req_dep.specified_revision, req_dep.name))
+
     req_dep.package.revision = req_dep.resolved_rev()
 
     found = ws.lock.get_package(req_dep.name)

--- a/lib/wit/workspace.py
+++ b/lib/wit/workspace.py
@@ -198,7 +198,7 @@ class WorkSpace:
         dep_pkg = dep.package
         dep_pkg.load_repo(self.root, download=True, needed_commit=dep.specified_revision)
 
-        if not dep_pkg.repo.has_commit(dep.specified_revision):
+        if not dep_pkg.repo.roughly_has_rev(dep.specified_revision):
             error("Cannot find commit '{}' in '{}'".format(dep.specified_revision, dep.name))
 
         dep_pkg.revision = dep.resolved_rev()

--- a/lib/wit/workspace.py
+++ b/lib/wit/workspace.py
@@ -197,6 +197,10 @@ class WorkSpace:
         dep.load_package(packages, self.repo_paths)
         dep_pkg = dep.package
         dep_pkg.load_repo(self.root, download=True, needed_commit=dep.specified_revision)
+
+        if not dep_pkg.repo.has_commit(dep.specified_revision):
+            error("Cannot find commit '{}' in '{}'".format(dep.specified_revision, dep.name))
+
         dep_pkg.revision = dep.resolved_rev()
 
         assert dep_pkg.repo is not None


### PR DESCRIPTION
In order to test this PR, merge #114 first. Afterwords, click <kbd>Edit</kbd> next to this PR title and use the dropdown to rebase onto `master`.

Before:
<details>
<pre>
$ wit add-pkg https://github.com/sifive/block-pio-sifive::11233
Adding package to workspace
Cloning block-pio-sifive...
Traceback (most recent call last):
  File "/Users/aaronj/wit/lib/wit/gitrepo.py", line 98, in get_commit
    self._git_check(proc)
  File "/Users/aaronj/wit/lib/wit/gitrepo.py", line 239, in _git_check
    raise GitError(msg)
wit.gitrepo.GitError: Command [git rev-parse 11233] exited with non-zero exit status [128]
stdout: [11233]
stderr: [fatal: ambiguous argument '11233': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]']


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/nix/store/jk588wcj1wg51kv2af3rb2j7lkl8h9b0-python3-3.5.7/lib/python3.5/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/nix/store/jk588wcj1wg51kv2af3rb2j7lkl8h9b0-python3-3.5.7/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/aaronj/wit/lib/wit/__main__.py", line 11, in <module>
    main()
  File "/Users/aaronj/wit/lib/wit/main.py", line 128, in main
    add_pkg(ws, args)
  File "/Users/aaronj/wit/lib/wit/main.py", line 193, in add_pkg
    ws.add_dependency(args.repo)
  File "/Users/aaronj/wit/lib/wit/workspace.py", line 200, in add_dependency
    dep_pkg.revision = dep.resolved_rev()
  File "/Users/aaronj/wit/lib/wit/dependency.py", line 107, in resolved_rev
    return self.package.repo.get_commit(self.specified_revision)
  File "/Users/aaronj/wit/lib/wit/gitrepo.py", line 101, in get_commit
    self._git_check(proc)
  File "/Users/aaronj/wit/lib/wit/gitrepo.py", line 239, in _git_check
    raise GitError(msg)
wit.gitrepo.GitError: Command [git rev-parse origin/11233] exited with non-zero exit status [128]
stdout: [origin/11233]
stderr: [fatal: ambiguous argument 'origin/11233': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]']
</pre>
</details>

After:
<details>
<pre>
$ wit add-pkg https://github.com/sifive/block-pio-sifive::11233
Adding package to workspace
[ERROR] Cannot find commit '11233' in 'block-pio-sifive'
</pre>
</details>