### PR TITLE
make invalid git remote non-fatal

### DIFF
--- a/lib/wit/dependency.py
+++ b/lib/wit/dependency.py
@@ -6,6 +6,7 @@ from typing import List  # noqa: F401
 from .common import passbyval, WitUserError
 from .package import Package
 from .witlogger import getLogger
+from .gitrepo import BadSource
 
 log = getLogger()
 
@@ -41,7 +42,11 @@ class Dependency:
         log.debug("Dependencies for [{}]: [{}]".format(self.name, subdeps))
         for subdep in subdeps:
             subdep.load_package(packages, repo_paths)
-            subdep.package.load_repo(wsroot, download, subdep.specified_revision)
+            try:
+                subdep.package.load_repo(wsroot, download, subdep.specified_revision)
+            except BadSource as e:
+                errors.append(e)
+                continue
 
             if subdep.name in source_map:
                 if subdep.package.resolve_source(subdep.source) != source_map[subdep.name]:

--- a/lib/wit/main.py
+++ b/lib/wit/main.py
@@ -209,7 +209,7 @@ def add_dep(ws, args) -> None:
 
     if not ws.lock.contains_package(cwd_dirname):
         raise NotAPackageError(
-            "'{}' is not a package in workspace at '{}'".format(cwd_dirname, ws.root))
+            "'{}' is not a package in workspace at '{}'".format(cwd_dirname, ws.path))
 
     req_dep = dependency_from_tag(args.pkg)
 

--- a/lib/wit/package.py
+++ b/lib/wit/package.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import re
 import os
 import shutil
-from .gitrepo import GitRepo
+from .gitrepo import GitRepo, BadSource
 from .witlogger import getLogger
 
 log = getLogger()
@@ -85,7 +85,11 @@ class Package:
             if not download:
                 self.repo = None
                 return
-            self.repo.download()
+            try:
+                self.repo.download()
+            except BadSource:
+                self.repo = None
+                raise
 
     def is_ancestor(self, other_commit):
         return self.repo.is_ancestor(other_commit, self.revision)


### PR DESCRIPTION
This allows people to partially clone a workspace even if they don't have permission to clone all the dependencies