### PR TITLE
Tag as optional field

### DIFF
--- a/lib/wit/dependency.py
+++ b/lib/wit/dependency.py
@@ -21,7 +21,7 @@ class DependeeNewerThanDepender(WitUserError):
                 "clock time being stored in a commit.\n This should be fixable "
                 "by creating a new commit in the dependee then depending on "
                 "that commit."
-                "".format(self.depender.tag(), self.dependee.tag()))
+                "".format(self.depender.id(), self.dependee.id()))
 
 
 class Dependency:
@@ -115,7 +115,7 @@ class Dependency:
         return self.package.repo.get_commit(self.specified_revision)
 
     def __repr__(self):
-        return "Dep({})".format(self.tag())
+        return "Dep({})".format(self.id())
 
     def short_revision(self):
         if self.package and self.package.repo:
@@ -124,14 +124,14 @@ class Dependency:
             return self.specified_revision
         return self.specified_revision[:8]
 
-    def tag(self):
+    def id(self):
         return "{}::{}".format(self.name, self.short_revision())
 
     def get_id(self):
-        return "dep_"+re.sub(r"([^\w\d])", "_", self.tag())
+        return "dep_"+re.sub(r"([^\w\d])", "_", self.id())
 
     def crawl_dep_tree(self, wsroot, repo_paths, packages):
-        fancy_tag = "{}::{}".format(self.name, self.short_revision())
+        fancy_tag = self.id()
         self.load(packages, repo_paths, wsroot, False)
         if self.package.repo is None:
             return {'': "{} \033[91m(missing)\033[m".format(fancy_tag)}

--- a/lib/wit/dependency.py
+++ b/lib/wit/dependency.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime
 from pathlib import Path
 from typing import List  # noqa: F401
+from collections import OrderedDict
 from .common import passbyval, WitUserError
 from .package import Package
 from .witlogger import getLogger
@@ -27,10 +28,11 @@ class DependeeNewerThanDepender(WitUserError):
 class Dependency:
     """ A dependency that a Package specifies. From wit-manifest.json and wit-workspace.js """
 
-    def __init__(self, name, source, specified_revision=None):
+    def __init__(self, name, source, specified_revision=None, tag=None):
         self.source = source
         self.revision = None
         self.specified_revision = specified_revision or "HEAD"
+        self.tag = tag  # type: Optional[str]
         self.name = name or Dependency.infer_name(source)
         self.package = None  # type: Package
         self.dependents = []  # type: List[Package]
@@ -97,22 +99,36 @@ class Dependency:
             self.specified_revision)))
 
     def manifest(self):
-        return {
-            'name': self.name,
-            'source': self.source,
-            'commit': self.specified_revision,
-        }
+        res = OrderedDict()
+        res['name'] = self.name
+        res['source'] = self.source
+        res['commit'] = self.specified_revision
+        if self.tag is not None:
+            res['tag'] = self.tag
+        return res
 
     # used before saving to manifests/lockfiles
     def resolved(self):
-        return Dependency(self.name, self.source, self.resolved_rev())
+        return Dependency(self.name, self.source, self.resolved_rev(), self.resolved_tag())
+
+    # Check if the Dependency has a Package and repo on disk
+    def _is_bound(self) -> bool:
+        return self.package is not None and self.package.repo is not None
 
     def resolved_rev(self):
-        if self.package.repo is None or self.package.repo is None:
+        if not self._is_bound():
             raise Exception("Cannot resolve dependency that is unbound to disk")
-        if self.package.repo.is_tag(self.specified_revision):
-            return self.specified_revision
         return self.package.repo.get_commit(self.specified_revision)
+
+    def resolved_tag(self):
+        if not self._is_bound():
+            raise Exception("Cannot resolve dependency that is unbound to disk")
+        if self.tag is None:
+            repo = self.package.repo
+            rev = self.specified_revision
+            return rev if repo.is_tag(rev) else None
+        else:
+            return self.tag
 
     def __repr__(self):
         return "Dep({})".format(self.id())
@@ -169,4 +185,4 @@ def parse_dependency_tag(s):
 
 def manifest_item_to_dep(obj):
     # source can be done due to repo path
-    return Dependency(obj['name'], obj.get('source', None), obj['commit'])
+    return Dependency(obj['name'], obj.get('source', None), obj['commit'], obj.get('tag', None))

--- a/lib/wit/inspect.py
+++ b/lib/wit/inspect.py
@@ -53,7 +53,7 @@ def _print_dot_tree(ws, packages_dict):
     for pkg in packages:
         pkg_id = pkg.get_id()
         pkg_ids.append(pkg_id)
-        log.output('{} [label="{}"]'.format(pkg_id, pkg.tag()))
+        log.output('{} [label="{}"]'.format(pkg_id, pkg.id()))
 
     drawn_connections = []
 
@@ -73,9 +73,9 @@ def _print_dot_tree(ws, packages_dict):
             log.error("Cannot generate graph with missing repo '{}'".format(dep.name))
             sys.exit(1)
         dep_pkg_id = dep.package.get_id()
-        if dep.tag() != dep.package.tag() or VERBOSE_GRAPH:
+        if dep.id() != dep.package.id() or VERBOSE_GRAPH:
             draw_connection(dep_id, dep_pkg_id, dotted=True)
-            log.output('{} [label="{}"]{}'.format(dep_id, dep.tag(),
+            log.output('{} [label="{}"]{}'.format(dep_id, dep.id(),
                                                   " [shape=box]" if BOXED_DEPS else ""))
             draw_connection(pkg_id, dep_id)
         else:

--- a/lib/wit/lock.py
+++ b/lib/wit/lock.py
@@ -60,4 +60,5 @@ def lockfile_item_to_pkg(item):
     pkg = Package(item['name'], [])
     pkg.set_source(item['source'])
     pkg.revision = item['commit']
+    pkg.tag = item.get('tag', None)
     return pkg

--- a/lib/wit/main.py
+++ b/lib/wit/main.py
@@ -249,7 +249,7 @@ def add_dep(ws, args) -> None:
     manifest.add_dependency(req_dep)
     manifest.write(manifest_path)
 
-    log.info("'{}' now depends on '{}'".format(cwd_dirname, req_dep.package.tag()))
+    log.info("'{}' now depends on '{}'".format(cwd_dirname, req_dep.package.id()))
 
 
 def update_dep(ws, args) -> None:
@@ -286,7 +286,7 @@ def update_dep(ws, args) -> None:
     manifest.replace_dependency(req_dep)
     manifest.write(cwd/'wit-manifest.json')
 
-    log.info("'{}' now depends on '{}'".format(cwd_dirname, req_pkg.tag()))
+    log.info("'{}' now depends on '{}'".format(cwd_dirname, req_pkg.id()))
 
 
 def status(ws, args) -> None:

--- a/lib/wit/package.py
+++ b/lib/wit/package.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import re
 import os
 import shutil
+from collections import OrderedDict
 from .gitrepo import GitRepo, BadSource
 from .witlogger import getLogger
 
@@ -32,6 +33,7 @@ class Package:
         self.name = name
         self.source = None
         self.revision = None
+        self.tag = None
         self.repo_paths = repo_paths
 
         self.repo = None
@@ -48,7 +50,7 @@ class Package:
         return None
 
     def __key(self):
-        return (self.source, self.revision, self.name)
+        return (self.source, self.revision, self.name, self.tag)
 
     def __hash__(self):
         return hash(self.__key())
@@ -115,11 +117,13 @@ class Package:
         return deps
 
     def manifest(self):
-        return {
-            'name': self.name,
-            'source': self.source,
-            'commit': self.revision,
-        }
+        res = OrderedDict()
+        res['name'] = self.name
+        res['source'] = self.source
+        res['commit'] = self.revision
+        if self.tag is not None:
+            res['tag'] = self.tag
+        return res
 
     # this is in Package because update_dependency is in Package
     # it could be confusing to keep the two functions separate

--- a/lib/wit/package.py
+++ b/lib/wit/package.py
@@ -157,13 +157,13 @@ class Package:
         self.repo.path = wsroot/self.repo.name
 
     def __repr__(self):
-        return "Pkg({})".format(self.tag())
+        return "Pkg({})".format(self.id())
 
-    def tag(self):
+    def id(self):
         return "{}::{}".format(self.name, self.short_revision())
 
     def get_id(self):
-        return "pkg_"+re.sub(r"([^\w\d])", "_", self.tag())
+        return "pkg_"+re.sub(r"([^\w\d])", "_", self.id())
 
     def status(self, lock):
         if lock.contains_package(self.name):

--- a/lib/wit/workspace.py
+++ b/lib/wit/workspace.py
@@ -43,12 +43,12 @@ class NotAncestorError(WitUserError):
                     orig_parent_name=orig_parent.name,
                     old_parent_name=old_parent.name,
 
-                    orig_parent_tag=orig_parent.tag(),
-                    old_parent_tag=old_parent.tag(),
+                    orig_parent_tag=orig_parent.id(),
+                    old_parent_tag=old_parent.id(),
 
                     child_name=child_name,
-                    orig_child_tag=self.orig_child.tag(),
-                    old_child_tag=self.old_child.tag(),
+                    orig_child_tag=self.orig_child.id(),
+                    old_child_tag=self.old_child.id(),
                 ))
 
 
@@ -66,7 +66,7 @@ class WorkSpace:
         self.manifest = self._load_manifest()
         self.lock = self._load_lockfile()
 
-    def tag(self):
+    def id(self):
         return "[root]"
 
     def get_id(self):
@@ -213,7 +213,7 @@ class WorkSpace:
         log.debug('my manifest_path = {}'.format(self.manifest_path()))
         self.manifest.write(self.manifest_path())
 
-        log.info("The workspace now depends on '{}'".format(dep.package.tag()))
+        log.info("The workspace now depends on '{}'".format(dep.package.id()))
 
     def update_dependency(self, tag) -> None:
         # init requested Dependency
@@ -257,7 +257,7 @@ class WorkSpace:
         self.manifest.replace_dependency(req_dep)
         self.manifest.write(self.manifest_path())
 
-        log.info("The workspace now depends on '{}'".format(req_dep.package.tag()))
+        log.info("The workspace now depends on '{}'".format(req_dep.package.id()))
 
         # if we differ from the lockfile, tell the user to update
         if not self.lock.get_package(req_dep.name).revision == req_resolved_rev:

--- a/lib/wit/workspace.py
+++ b/lib/wit/workspace.py
@@ -156,6 +156,7 @@ class WorkSpace:
             packages[dep.name] = dep.package
             packages[dep.name].revision = dep.resolved_rev()
             packages[dep.name].set_source(dep.source)
+            packages[dep.name].tag = dep.tag
 
             source_map, packages, queue, errors = \
                 dep.resolve_deps(self.root, self.repo_paths, download,

--- a/t/regress_util.sh
+++ b/t/regress_util.sh
@@ -32,12 +32,13 @@ check() {
 
 prereq() {
     if [ "$1" = "off" ]
-    then in_prereq=0; set +e
-    else in_prereq=1; set -e
+    then in_prereq=0; set +e -x
+    else in_prereq=1; set -e +x
     fi
 }
 
 report() {
+    set +x
     echo "PASS: $pass"
     echo "FAIL: $fail"
 }

--- a/t/regress_util.sh
+++ b/t/regress_util.sh
@@ -10,6 +10,13 @@ fail=0
 pass=0
 in_prereq=0
 
+into_test_dir() {
+    filename=`basename $0`
+    dir="testdir.${filename%.*}"
+    mkdir $dir
+    cd $dir
+}
+
 make_repo() {
     repo_name=$1
 

--- a/t/wit_add.t
+++ b/t/wit_add.t
@@ -2,12 +2,13 @@
 
 . $(dirname $0)/regress_util.sh
 
+prereq off
+
 # Set up repo foo
 make_repo 'foo'
 foo_commit=$(git -C foo rev-parse HEAD)
 foo_dir=$PWD/foo
 
-set -x
 # Now create an empty workspace
 wit init myws
 
@@ -17,8 +18,6 @@ check "wit add-pkg should succeed" [ $? -eq 0 ]
 
 foo_ws_commit=$(jq -r '.[] | select(.name=="foo") | .commit' wit-workspace.json)
 check "Added repo should have correct commit" [ "$foo_ws_commit" = "$foo_commit" ]
-
-set +x
 
 report
 finish

--- a/t/wit_add_dep.t
+++ b/t/wit_add_dep.t
@@ -31,8 +31,6 @@ bar_dir=$PWD/bar
 
 prereq off
 
-set -x
-
 # Now create an empty workspace
 wit init myws
 
@@ -54,8 +52,6 @@ check "foo should depend on the correct commit of bar" [ "$foo_bar_commit" = "$b
 
 bar_manifest_source=$(jq -r '.[] | select(.name=="bar") | .source' foo/wit-manifest.json)
 check "Added bar dependency should have correct source" [ "$bar_manifest_source" = "$bar_dir" ]
-
-set +x
 
 report
 finish

--- a/t/wit_add_dep_already_cloned.t
+++ b/t/wit_add_dep_already_cloned.t
@@ -2,6 +2,8 @@
 
 . $(dirname $0)/regress_util.sh
 
+prereq on
+
 # Set up repo foo
 make_repo 'foo'
 foo_commit=$(git -C foo rev-parse HEAD)
@@ -15,7 +17,8 @@ git -C bar add -A
 git -C bar commit -m "commit2"
 bar_commit2=$(git -C bar rev-parse HEAD)
 
-set -x
+prereq off
+
 # Now create an empty workspace
 wit init myws -a $foo_dir
 
@@ -33,8 +36,6 @@ check "Added bar dependency should have correct commit" [ "$bar_manifest_commit"
 
 bar_manifest_source=$(jq -r '.[] | select(.name=="bar") | .source' foo/wit-manifest.json)
 check "Added bar dependency should have correct source" [ "$bar_manifest_source" = "$bar_dir" ]
-
-set +x
 
 report
 finish

--- a/t/wit_add_dep_in_workspace.t
+++ b/t/wit_add_dep_in_workspace.t
@@ -2,6 +2,8 @@
 
 . $(dirname $0)/regress_util.sh
 
+prereq on
+
 # Set up repo foo
 make_repo 'foo'
 foo_commit1=$(git -C foo rev-parse HEAD)
@@ -28,7 +30,7 @@ EOF
 git -C fizz add -A
 git -C fizz commit -m "Add dep on bar"
 
-set -x
+prereq off
 
 wit init myws -a $fizz_dir
 cd myws
@@ -44,8 +46,6 @@ check "Added foo dependency should have correct commit" [ "$foo_manifest_commit"
 
 foo_manifest_source=$(jq -r '.[] | select(.name=="foo") | .source' fizz/wit-manifest.json)
 check "Added foo dependency should have correct source" [ "$foo_manifest_source" = "$foo_dir" ]
-
-set +x
 
 report
 finish

--- a/t/wit_add_dep_not_repo.t
+++ b/t/wit_add_dep_not_repo.t
@@ -24,16 +24,12 @@ make_repo 'fizz'
 
 prereq off
 
-set -x
-
 # Now try to make bar depend on foo
 msg=$(wit -C bar add-dep $foo_dir)
 check "Adding dependency to non-package should fail" [ $? -ne 0 ]
 
 msg=$(wit -C fizz add-dep $foo_dir)
 check "Adding dependency to non-workspace repo should fail" [ $? -ne 0 ]
-
-set +x
 
 report
 finish

--- a/t/wit_add_pkg_already_cloned.t
+++ b/t/wit_add_pkg_already_cloned.t
@@ -2,12 +2,15 @@
 
 . $(dirname $0)/regress_util.sh
 
+prereq on
+
 # Set up repo foo
 make_repo 'foo'
 foo_commit=$(git -C foo rev-parse HEAD)
 foo_dir=$PWD/foo
 
-set -x
+prereq off
+
 # Now create an empty workspace
 wit init myws
 
@@ -22,8 +25,6 @@ check "Added repo should have correct commit" [ "$foo_ws_commit" = "$foo_commit"
 
 foo_ws_source=$(jq -r '.[] | select(.name=="foo") | .source' wit-workspace.json)
 check "Added repo should have source copied from remote" [ "$foo_ws_source" = "$foo_dir" ]
-
-set +x
 
 report
 finish

--- a/t/wit_add_pkg_already_dep.t
+++ b/t/wit_add_pkg_already_dep.t
@@ -2,6 +2,8 @@
 
 . $(dirname $0)/regress_util.sh
 
+prereq on
+
 # Set up repo foo
 make_repo 'foo'
 foo_commit1=$(git -C foo rev-parse HEAD)
@@ -12,7 +14,8 @@ make_repo 'bar'
 bar_commit=$(git -C bar rev-parse HEAD)
 bar_dir=$PWD/bar
 
-set -x
+prereq off
+
 # Now create an empty workspace
 wit init myws
 
@@ -37,8 +40,6 @@ wit update
 
 foo_ws_source=$(jq -r '.[] | select(.name=="foo") | .source' wit-workspace.json)
 check "Added repo should have source copied from remote" [ "$foo_ws_source" = "$foo_dir" ]
-
-set +x
 
 report
 finish

--- a/t/wit_add_pkg_exists.t
+++ b/t/wit_add_pkg_exists.t
@@ -2,12 +2,15 @@
 
 . $(dirname $0)/regress_util.sh
 
+prereq on
+
 # Set up repo foo
 make_repo 'foo'
 foo_commit=$(git -C foo rev-parse HEAD)
 foo_dir=$PWD/foo
 
-set -x
+prereq off
+
 # Now create an empty workspace
 wit init myws
 
@@ -17,8 +20,6 @@ check "wit add-pkg should succeed" [ $? -eq 0 ]
 
 wit add-pkg $foo_dir
 check "wit add-pkg a second time should fail" [ $? -eq 1 ]
-
-set +x
 
 report
 finish

--- a/t/wit_deleted_pkg.t
+++ b/t/wit_deleted_pkg.t
@@ -16,15 +16,11 @@ rm -rf foo
 
 prereq off
 
-set -x
-
 wit update
 check "wit should redownload a deleted package" [ $? -eq 0 ]
 
 foo_ws_commit=$(git -C foo rev-parse HEAD)
 check "The checked out commit should be correct" [ "$foo_ws_commit" = "$foo_commit" ]
-
-set +x
 
 report
 finish

--- a/t/wit_head_attachment.t
+++ b/t/wit_head_attachment.t
@@ -36,8 +36,6 @@ cd myws
 
 prereq off
 
-set -x
-
 wit add-pkg $foo_dir
 wit update
 
@@ -78,8 +76,6 @@ wit update
 status=$(git -C foo status --porcelain -b | md5)
 golden=$(echo "## master...origin/master" | md5)
 check "head should stay attached to same branch when not moved" [ $status = $golden ]
-
-set +x
 
 report
 finish

--- a/t/wit_status.t
+++ b/t/wit_status.t
@@ -16,8 +16,6 @@ git -C bar add -A
 git -C bar commit -m "commit1"
 bar_commit=$(git -C bar rev-parse HEAD)
 
-set -x
-
 prereq off
 
 # Now create a workspace from bar
@@ -26,8 +24,6 @@ cd myws
 
 wit status
 check "wit status should not fail" [ $? -eq 0 ]
-
-set +x
 
 report
 finish

--- a/t/wit_tags.t
+++ b/t/wit_tags.t
@@ -4,6 +4,8 @@
 
 prereq on
 
+into_test_dir
+
 # Set up repo foo
 make_repo 'foo'
 foo_commit=$(git -C foo rev-parse HEAD)
@@ -14,6 +16,12 @@ git -C foo add -A
 git -C foo commit -m "commit2"
 git -C foo tag "v1.0.0"
 foo_commit2=$(git -C foo rev-parse HEAD)
+echo "yo" > foo/file3
+git -C foo add -A
+git -C foo commit -m "commit3"
+git -C foo tag "some-tag"
+git -C foo tag "v2.0.0"
+foo_commit3=$(git -C foo rev-parse HEAD)
 
 make_repo 'bar'
 # Make bar depend on foo
@@ -26,35 +34,95 @@ git -C bar add -A
 git -C bar commit -m "commit2"
 bar_dir=$PWD/bar
 
-wit init myws -a $bar_dir
-cd myws
-
 prereq off
 
-wit -C bar update-dep foo
-check "Updating foo in bar should work, but..." [ $? -eq 0 ]
+# ********** Tests of a package in the workspace **********
+wit init ws1
+cd ws1
+wit add-pkg $foo_dir
+jq -re '.[] | select(.name=="foo") | .tag' wit-workspace.json
+check "Cloning from remote with no specified tag should NOT have a tag" [ $? -eq 1 ]
 
-foo_dep_commit=$(jq -r '.[] | select(.name=="foo") | .commit' bar/wit-manifest.json)
-check "Foos commit in bar's manifest should be unchanged" [ "$foo_dep_commit" = "$foo_commit" ]
+wit update-pkg foo::v1.0.0
+foo_ws_tag=$(jq -r '.[] | select(.name=="foo") | .tag' wit-workspace.json)
+check "Updating a package with a specified tag should have a tag" [ "$foo_ws_tag" = "v1.0.0" ]
 
-check "Checked out foo commit should be unchanged" [ "$(git -C foo rev-parse HEAD)" = "$foo_commit" ]
+## TODO Unfortunately this may not be possible
+#git -C foo checkout v2.0.0
+#wit update-pkg foo
+#foo_ws_tag=$(jq -r '.[] | select(.name=="foo") | .tag' wit-workspace.json)
+#msg="Updating a package with no specified revision but checked out tag should have a tag"
+#check "$msg" [ "$foo_ws_tag" = "v2.0.0" ]
+
+cd ..
+wit init ws2
+cd ws2
+wit add-pkg $foo_dir::v1.0.0
+foo_ws_tag=$(jq -r '.[] | select(.name=="foo") | .tag' wit-workspace.json)
+check "Cloning from remote with specified tag should have a tag" [ "$foo_ws_tag" = "v1.0.0" ]
+
+cd ..
+wit init ws3
+cd ws3
+git clone $foo_dir
+wit add-pkg foo
+jq -re '.[] | select(.name=="foo") | .tag' wit-workspace.json
+check "Adding a cloned repo with no specified tag and no tag checked out should NOT have a tag" [ $? -eq 1 ]
+
+## TODO Unfortunately this may not be possible
+#cd ..
+#wit init ws4
+#cd ws4
+#git clone $foo_dir
+#git -C foo checkout v1.0.0
+#wit add-pkg foo
+#foo_ws_tag=$(jq -r '.[] | select(.name=="foo") | .tag' wit-workspace.json)
+#check "Adding a cloned repo with a tag checked out *should* have a tag" [ "$foo_ws_tag" = "v1.0.0" ]
+
+# ********** Tests of a dependency of another package **********
+cd ..
+wit init ws5 -a $bar_dir
+cd ws5
 
 wit -C bar update-dep foo::v1.0.0
-check "Updating foo to master should work" [ $? -eq 0 ]
+check "Updating foo to a tag should work" [ $? -eq 0 ]
 
 foo_dep_commit=$(jq -r '.[] | select(.name=="foo") | .commit' bar/wit-manifest.json)
-check "Foos commit in bar's manifest should have bumped" [ "$foo_dep_commit" = "v1.0.0" ]
+check "Foos commit in bar's manifest should have bumped" [ "$foo_dep_commit" = "$foo_commit2" ]
+
+foo_dep_tag=$(jq -r '.[] | select(.name=="foo") | .tag' bar/wit-manifest.json)
+check "Foo in bar's manifest should have have a tag" [ "$foo_dep_tag" = "v1.0.0" ]
 
 check "Checked out foo commit should be unchanged" [ "$(git -C foo rev-parse HEAD)" = "$foo_commit" ]
 
 # Bump foo in bar
 git -C bar add -A
-git -C bar commit -m "bump foo"
+git -C bar commit -m "bump foo to v1.0.0"
 # Now update the workspace with the bump
 wit update-pkg bar
 wit update
 
 check "Checked out foo commit should have bumped" [ "$(git -C foo rev-parse HEAD)" = "$foo_commit2" ]
+
+foo_lock_commit=$(jq -r '.foo.commit' wit-lock.json)
+check "Lock file should contain foo commit" [ "$foo_lock_commit" = "$foo_commit2" ]
+
+foo_lock_tag=$(jq -r '.foo.tag' wit-lock.json)
+check "Lock file should contain foo tag" [ "$foo_lock_tag" = "v1.0.0" ]
+
+#wit -C bar update-dep foo::origin/master
+#jq -re '.[] | select(.name=="foo") | .tag' bar/wit-manifest.json
+#check "When no tag is specified, don't have one" [ $? -eq 1 ]
+#
+### TODO Unfortunately this may not be possible
+##git -C foo checkout v2.0.0
+##wit -C bar update-dep foo
+##foo_dep_tag=$(jq -r '.[] | select(.name=="foo") | .tag' bar/wit-manifest.json)
+##check "When no revision is specified but a tag is checked out, have the tag" [ "$foo_dep_tag" = "v2.0.0" ]
+#
+#wit -C bar update-dep foo::some-tag
+#foo_dep_tag=$(jq -r '.[] | select(.name=="foo") | .tag' bar/wit-manifest.json)
+#check "Support specifying the tag" [ "$foo_dep_tag" = "some-tag" ]
 
 report
 finish

--- a/t/wit_tags.t
+++ b/t/wit_tags.t
@@ -31,8 +31,6 @@ cd myws
 
 prereq off
 
-set -x
-
 wit -C bar update-dep foo
 check "Updating foo in bar should work, but..." [ $? -eq 0 ]
 
@@ -57,8 +55,6 @@ wit update-pkg bar
 wit update
 
 check "Checked out foo commit should have bumped" [ "$(git -C foo rev-parse HEAD)" = "$foo_commit2" ]
-
-set +x
 
 report
 finish

--- a/t/wit_update.t
+++ b/t/wit_update.t
@@ -2,6 +2,8 @@
 
 . $(dirname $0)/regress_util.sh
 
+prereq on
+
 # Set up repo foo
 make_repo 'foo'
 foo_commit=$(git -C foo rev-parse HEAD)
@@ -14,7 +16,7 @@ git -C bar add -A
 git -C bar commit -m "commit1"
 bar_commit=$(git -C bar rev-parse HEAD)
 
-set -x
+prereq off
 
 # Now create a workspace from bar
 wit init myws -a $PWD/bar
@@ -29,8 +31,6 @@ check "ws-lock.json should contain correct foo commit" [ "$foo_lock_commit" = "$
 
 bar_lock_commit=$(jq -r '.bar.commit' wit-lock.json)
 check "ws-lock.json should contain correct bar commit" [ "$bar_lock_commit" = "$bar_commit" ]
-
-set +x
 
 report
 finish

--- a/t/wit_update_dep.t
+++ b/t/wit_update_dep.t
@@ -30,8 +30,6 @@ cd myws
 
 prereq off
 
-set -x
-
 wit -C bar update-dep foo
 check "Updating foo in bar should work, but..." [ $? -eq 0 ]
 
@@ -56,8 +54,6 @@ wit update-pkg bar
 wit update
 
 check "Checked out foo commit should have bumped" [ "$(git -C foo rev-parse HEAD)" = "$foo_commit2" ]
-
-set +x
 
 report
 finish

--- a/t/wit_update_dep_fetch.t
+++ b/t/wit_update_dep_fetch.t
@@ -32,15 +32,11 @@ cd myws
 
 prereq off
 
-set -x
-
 wit -C bar update-dep foo::origin/master
 check "Updating foo to origin/master in bar should work" [ $? -eq 0 ]
 
 foo_dep_commit=$(jq -r '.[] | select(.name=="foo") | .commit' bar/wit-manifest.json)
 check "Foos commit in bar's manifest should have bumped" [ "$foo_dep_commit" = "$foo_commit2" ]
-
-set +x
 
 report
 finish

--- a/t/wit_update_fetch.t
+++ b/t/wit_update_fetch.t
@@ -2,6 +2,8 @@
 
 . $(dirname $0)/regress_util.sh
 
+prereq on
+
 # Set up repo foo
 make_repo 'foo'
 foo_commit1=$(git -C foo rev-parse HEAD)
@@ -37,7 +39,7 @@ git -C bar add -A
 git -C bar commit -m "commit3"
 bar_commit2=$(git -C bar rev-parse HEAD)
 
-set -x
+prereq off
 
 cd myws
 
@@ -53,8 +55,6 @@ check "the correct commit of foo should be checked out" [ "$foo_ws_commit" = "$f
 
 bar_ws_commit=$(git -C bar rev-parse HEAD)
 check "the correct commit of bar should be checked out" [ "$bar_ws_commit" = "$bar_commit2" ]
-
-set +x
 
 report
 finish

--- a/t/wit_update_pkg.t
+++ b/t/wit_update_pkg.t
@@ -19,8 +19,6 @@ git -C foo checkout master
 
 prereq off
 
-set -x
-
 wit init myws -a $foo_dir::$foo_commit
 cd myws
 
@@ -45,8 +43,6 @@ check "foo should have checked out the right commit" [ "$commit" = "$foo_commit_
 
 foo_lock_commit2=$(jq -r '.foo | .commit' wit-lock.json)
 check "After 'wit update', the lock should contain the correct commit" [ "$foo_lock_commit2" = "$foo_commit_branch" ]
-
-set +x
 
 report
 finish

--- a/t/wit_update_pkg_fetch.t
+++ b/t/wit_update_pkg_fetch.t
@@ -21,8 +21,6 @@ cd myws
 
 prereq off
 
-set -x
-
 git -C foo cat-file -t $foo_commit2
 check "The remote commit should not yet be known in local foo checkout" [ $? -ne 0 ]
 
@@ -33,8 +31,6 @@ wit update
 
 foo_repo_commit=$(git -C foo rev-parse HEAD)
 check "The correct foo commit should be checked out" [ "$foo_repo_commit" = "$foo_commit2" ]
-
-set +x
 
 report
 finish

--- a/t/wit_update_pkg_not_in_workspace.t
+++ b/t/wit_update_pkg_not_in_workspace.t
@@ -26,8 +26,6 @@ cd myws
 
 prereq off
 
-set -x
-
 wit update-pkg potato
 check "Updating a package not in the workspace should fail" [ $? -ne 0 ]
 
@@ -35,8 +33,6 @@ check "foo should have been pulled in as a dependency" [ -d foo ]
 
 wit update-pkg foo
 check "Updating a package not in the lock file but not the workspace should fail" [ $? -ne 0 ]
-
-set +x
 
 report
 finish


### PR DESCRIPTION
Each commit is separate

This no longer will put `tags` in the "commit" field, instead has a new optional field. It can only fill the tag field if the user tells it about the tag via `::<tag>`.

Unfortunately, if you check out a tag, it detaches HEAD and there isn't a super robust way to figure out which tag you checked out.