### PR TITLE
Update pkg before update

### DIFF
--- a/lib/wit/main.py
+++ b/lib/wit/main.py
@@ -203,8 +203,12 @@ def update_pkg(ws, args) -> None:
 def dependency_from_tag(wsroot, tag):
     source, revision = tag
 
+    dotwit = wsroot / ".wit"
     if (wsroot/source).exists() and (wsroot/source).parent == wsroot:
         repo = GitRepo((wsroot/source).name, wsroot)
+        source = repo.get_remote()
+    elif (dotwit/source).exists() and (dotwit/source).parent == dotwit:
+        repo = GitRepo((dotwit/source).name, dotwit)
         source = repo.get_remote()
     elif (wsroot/source).exists():
         source = str((wsroot/source).resolve())

--- a/lib/wit/workspace.py
+++ b/lib/wit/workspace.py
@@ -246,13 +246,13 @@ class WorkSpace:
             raise PackageNotInWorkspaceError(msg)
 
         try:
-            req_resolved_rev = req_dep.resolved_rev()
+            req_dep.package.revision = req_dep.resolved_rev()
         except GitCommitNotFound:
             raise WitUserError("Could not find commit or reference '{}' in '{}'"
                                "".format(req_dep.specified_revision, req_dep.name))
 
         # compare the requested revision to the revision in the wit-workspace.json
-        if manifest_dep.resolved_rev() == req_resolved_rev:
+        if manifest_dep.resolved_rev() == req_dep.package.revision:
             log.warn("Updating '{}' to the same revision it already is!".format(req_dep.name))
 
         self.manifest.replace_dependency(req_dep)
@@ -261,7 +261,8 @@ class WorkSpace:
         log.info("The workspace now depends on '{}'".format(req_dep.package.id()))
 
         # if we differ from the lockfile, tell the user to update
-        if not self.lock.get_package(req_dep.name).revision == req_resolved_rev:
+        if ((not self.lock.contains_package(req_dep.name) or
+             not self.lock.get_package(req_dep.name).revision == req_dep.package.revision)):
             log.info("Don't forget to run 'wit update'!")
 
     # Enable prettyish-printing of the class

--- a/t/wit_update_pkg.t
+++ b/t/wit_update_pkg.t
@@ -4,23 +4,39 @@
 
 prereq on
 
+into_test_dir
+
 # Set up repo foo
 make_repo 'foo'
 foo_commit=$(git -C foo rev-parse HEAD)
 foo_dir=$PWD/foo
+echo "what's up?" > foo/other
+git -C foo add -A
+git -C foo commit -m "commit2"
+foo_commit2=$(git -C foo rev-parse HEAD)
 # Create a branch with a commit
 echo "blah" > foo/file2
 git -C foo checkout -b branch
 git -C foo add -A
-git -C foo commit -m "commit2"
+git -C foo commit -m "branch commit"
 foo_commit_branch=$(git -C foo rev-parse HEAD)
 # Now return to master
 git -C foo checkout master
 
 prereq off
 
-wit init myws -a $foo_dir::$foo_commit
+wit init myws
 cd myws
+
+wit add-pkg $foo_dir::$foo_commit2
+
+wit update-pkg foo::$foo_commit
+check "We should be able to update-pkg without calling update" [ $? -eq 0 ]
+foo_remote=$(jq -r '.[] | select(.name=="foo") | .source' wit-workspace.json)
+check "update-pkg should leave the source unchanged" [ "$foo_remote" = "$foo_dir" ]
+
+wit update
+check "Wit update should succeed" [ $? -eq 0 ]
 
 # Check that "branch" is not a valid branch locally
 git -C foo rev-parse branch

--- a/t/wit_update_pkg_not_in_workspace.t
+++ b/t/wit_update_pkg_not_in_workspace.t
@@ -32,7 +32,7 @@ check "Updating a package not in the workspace should fail" [ $? -ne 0 ]
 check "foo should have been pulled in as a dependency" [ -d foo ]
 
 wit update-pkg foo
-check "Updating a package not in the lock file but not the workspace should fail" [ $? -ne 0 ]
+check "Updating a package in the lock file but not in the workspace should fail" [ $? -ne 0 ]
 
 report
 finish


### PR DESCRIPTION
This includes two related fixes:
1. Find staged repos in `<workspace>/.wit` since they may not have been pulled in by a `wit update` yet
1. Report the correct revision when updating a package, I'm not really sure how it was every right before

**EDIT:** It used to have 3 "fixes", but one was wrong. It was from an earlier attempt to solve (1) but broke other stuff.