### PR TITLE
Improve performance

### DIFF
--- a/lib/wit/common.py
+++ b/lib/wit/common.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import sys
-from copy import deepcopy
 from .witlogger import getLogger
 
 log = getLogger()
@@ -26,12 +25,3 @@ class WitUserError(Exception):
     Supertype of user-input errors that should be reported without stack traces
     """
     pass
-
-
-# https://stackoverflow.com/a/845194
-def passbyval(func):
-    def new(self, *args, **kwargs):
-        copy_args = [deepcopy(arg) for arg in args]
-        copy_kwargs = {key: deepcopy(val) for key, val in kwargs.iteritems()} if kwargs else {}
-        return func(self, *copy_args, **copy_kwargs)
-    return new

--- a/lib/wit/dependency.py
+++ b/lib/wit/dependency.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List  # noqa: F401
 from collections import OrderedDict
-from .common import passbyval, WitUserError
+from .common import WitUserError
 from .package import Package
 from .witlogger import getLogger
 from .gitrepo import BadSource
@@ -35,8 +35,11 @@ class Dependency:
         self.package = None  # type: Package
         self.dependents = []  # type: List[Package]
 
-    @passbyval
     def resolve_deps(self, wsroot, repo_paths, download, source_map, packages, queue, errors):
+        source_map = source_map.copy()
+        packages = packages.copy()
+        queue = queue.copy()
+        errors = errors.copy()
         subdeps = self.package.get_dependencies()
         log.debug("Dependencies for [{}]: [{}]".format(self.name, subdeps))
         for subdep in subdeps:

--- a/lib/wit/inspect.py
+++ b/lib/wit/inspect.py
@@ -1,5 +1,5 @@
 import sys
-from .common import passbyval, print_errors
+from .common import print_errors
 from .witlogger import getLogger
 
 log = getLogger()
@@ -27,8 +27,8 @@ BOXED_DEPS = False
 VERBOSE_GRAPH = False
 
 
-@passbyval
 def _deduplicate_tree(tree, seen=None):
+    tree = tree.copy()
     seen = seen or []
     tag = tree.pop('')
     ident = tag[-8:]

--- a/lib/wit/workspace.py
+++ b/lib/wit/workspace.py
@@ -7,7 +7,7 @@ from pprint import pformat
 from .manifest import Manifest
 from .dependency import Dependency, sources_conflict_check
 from .lock import LockFile
-from .common import WitUserError, error, passbyval
+from .common import WitUserError, error
 from .witlogger import getLogger
 from .gitrepo import GitCommitNotFound
 
@@ -177,8 +177,9 @@ class WorkSpace:
 
         return packages, errors
 
-    @passbyval
     def resolve_deps(self, wsroot, repo_paths, download, source_map, packages, queue, errors):
+        source_map = source_map.copy()
+        queue = queue.copy()
         for dep in self.manifest.dependencies:
             dep.load(packages, repo_paths, wsroot, download)
 

--- a/t/wit_update_dep_fetch.t
+++ b/t/wit_update_dep_fetch.t
@@ -4,6 +4,8 @@
 
 prereq on
 
+into_test_dir
+
 # Set up repo foo
 make_repo 'foo'
 foo_commit=$(git -C foo rev-parse HEAD)


### PR DESCRIPTION
I noticed some low-hanging fruit performance issues, this PR fixes 2 of them:
1. `passbyval` was eating a ton of time, the code shows that only shallow clones are necessary
2. Some git commands were repeated, this caches the most common ones

There is a small risk of bugs here, I may have misunderstood the uses of `passbyval` and maybe my caching strategy is incorrect. In fact, I got the caching wrong the first time which is why the `GitRepos` now record "known commits" and will only cache things keyed by known commits.

In any case, this is a huge improvement in performance to common operations like `wit status`, benchmarking results to follow