### PR TITLE
Remove unconditional directory creation prior to `git clone`.

### DIFF
--- a/lib/wit/gitrepo.py
+++ b/lib/wit/gitrepo.py
@@ -79,8 +79,8 @@ class GitRepo:
             "Trying to clone and checkout into existing git repo!"
         log.info('Cloning {}...'.format(self.name))
 
-        self.path.mkdir()
-        proc = self._git_command("clone", "--no-checkout", source, str(self.path))
+        proc = self._git_command("clone", "--no-checkout", source, str(self.path),
+                                 working_dir=str(self.path.parent))
         try:
             self._git_check(proc)
         except GitError:
@@ -283,11 +283,14 @@ class GitRepo:
             'commit': revision,
         }
 
-    def _git_command(self, *args):
-        log.debug("Executing [{}] in [{}]".format(' '.join(['git', *args]), self.path))
-        proc = subprocess.run(['git', *args], stdout=subprocess.PIPE,
+    def _git_command(self, *args, working_dir=None):
+        cwd = str(self.path) if working_dir is None else str(working_dir)
+        log.debug("Executing [{}] in [{}]".format(' '.join(['git', *args]), cwd))
+        proc = subprocess.run(['git', *args],
+                              stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE,
-                              cwd=str(self.path), universal_newlines=True)
+                              universal_newlines=True,
+                              cwd=cwd)
         return proc
 
     def _git_check(self, proc):

--- a/t/wit_add_pkg_bad_path.t
+++ b/t/wit_add_pkg_bad_path.t
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+. $(dirname $0)/test_util.sh
+
+prereq on
+
+# Set up repo foo
+make_repo 'foo'
+foo_commit1=$(git -C foo rev-parse HEAD)
+foo_dir=$PWD/foo
+
+prereq off
+
+# Now create an empty workspace
+wit init myws
+cd myws
+
+# fail to add a package that has the correct name, but an incorrect path
+wit add-pkg $foo_dir/foo
+
+# add package with correct path
+wit add-pkg $foo_dir
+check "wit add-pkg should succeed regardless of past failed attempts with same name" [ $? -eq 0 ]
+
+report
+finish


### PR DESCRIPTION
Otherwise if the clone fails we have a directory to clean up.
Instead rely on `git clone` itself to do creation and cleanup.
Closes #169