### PR TITLE
Provide git repo name in _git_check() error message

### DIFF
--- a/lib/wit/gitrepo.py
+++ b/lib/wit/gitrepo.py
@@ -295,8 +295,8 @@ class GitRepo:
 
     def _git_check(self, proc):
         if proc.returncode:
-            msg = "Command [{}] exited with non-zero exit status [{}]\n".format(
-                  ' '.join(proc.args), proc.returncode)
+            msg = "Command [{}] in [{}] exited with non-zero exit status [{}]\n".format(
+                  ' '.join(proc.args), str(self.path), proc.returncode)
             msg += "stdout: [{}]\n".format(proc.stdout.rstrip())
             msg += "stderr: [{}]\n".format(proc.stderr.rstrip())
             raise GitError(msg)


### PR DESCRIPTION
If a dependancy specificed in a wit-manifest.json requires a commit that doesn't exist, it could be difficult to figure out which repository was missing the commit.
This adds a path to error so that it's now in the form:
```
wit.gitrepo.GitError: Command [git log -n1 --format=%ct aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa] in [/Users/mmjconolly/work/workspace/somerepo] exited with non-zero exit status [128]
stdout: []
stderr: [fatal: bad object aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]
```