### PR TITLE
Refactor parser

### DIFF
--- a/lib/wit/main.py
+++ b/lib/wit/main.py
@@ -24,7 +24,7 @@ from .common import error, WitUserError, print_errors
 from .gitrepo import GitRepo, GitCommitNotFound
 from .manifest import Manifest
 from .package import WitBug
-from .parser import parser
+from .parser import parser, add_dep_parser
 import re
 
 log = getLogger()
@@ -163,9 +163,8 @@ def add_dep(ws, args) -> None:
 
     cwd = Path(os.getcwd()).resolve()
     if cwd == ws.root:
-        error("add-dep must be run inside of a package, not the workspace root.\n"
-              "  A dependency is added to the package determined by the current working "
-              "directory,\n  which can also be set by -C.")
+        error("add-dep must be run inside of a package, not the workspace root.\n\n" +
+              add_dep_parser.format_help())
     cwd_dirname = cwd.relative_to(ws.root).parts[0]
     if not ws.lock.contains_package(cwd_dirname):
         raise NotAPackageError(

--- a/lib/wit/main.py
+++ b/lib/wit/main.py
@@ -12,11 +12,10 @@
 
 import subprocess
 import sys
-import argparse
 import os
 from .witlogger import getLogger
 from .workspace import WorkSpace, PackageNotInWorkspaceError
-from .dependency import parse_dependency_tag, Dependency
+from .dependency import Dependency
 from .inspect import inspect_tree
 from . import scalaplugin
 from pathlib import Path
@@ -25,6 +24,7 @@ from .common import error, WitUserError, print_errors
 from .gitrepo import GitRepo, GitCommitNotFound
 from .manifest import Manifest
 from .package import WitBug
+from .parser import parser
 import re
 
 log = getLogger()
@@ -35,60 +35,6 @@ class NotAPackageError(WitUserError):
 
 
 def main() -> None:
-    # Parse arguments. Create sub-commands for each of the modes of operation
-    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('-v', '--verbose', action='count', default=0,
-                        help='''Specify level of verbosity
--v:    verbose
--vv:   debug
--vvv:  trace
--vvvv: spam
-''')
-    parser.add_argument('--version', action='store_true', help='Print wit version')
-    parser.add_argument('-C', dest='cwd', type=chdir, metavar='path', help='Run in given path')
-    parser.add_argument('--repo-path', default=os.environ.get('WIT_REPO_PATH'),
-                        help='Specify alternative paths to look for packages')
-    parser.add_argument('--prepend-repo-path', default=None,
-                        help='Prepend paths to the default repo search path.')
-
-    subparsers = parser.add_subparsers(dest='command', help='sub-command help')
-
-    init_parser = subparsers.add_parser('init', help='create workspace')
-    init_parser.add_argument('--no-update', dest='update', action='store_false',
-                             help=('don\'t run update upon creating the workspace'
-                                   ' (implies --no-fetch-scala)'))
-    init_parser.add_argument('--no-fetch-scala', dest='fetch_scala', action='store_false',
-                             help='don\'t run fetch-scala upon creating the workspace')
-    init_parser.add_argument('-a', '--add-pkg', metavar='repo[::revision]', action='append',
-                             type=parse_dependency_tag, help='add an initial package')
-    init_parser.add_argument('workspace_name')
-
-    add_pkg_parser = subparsers.add_parser('add-pkg', help='add a package to the workspace')
-    add_pkg_parser.add_argument('repo', metavar='repo[::revision]', type=parse_dependency_tag)
-
-    update_pkg_parser = subparsers.add_parser('update-pkg', help='update the revision of a '
-                                              'previously added package')
-    update_pkg_parser.add_argument('repo', metavar='repo[::revision]', type=parse_dependency_tag)
-
-    add_dep_parser = subparsers.add_parser('add-dep', help='add a dependency to a package')
-    add_dep_parser.add_argument('pkg', metavar='pkg[::revision]', type=parse_dependency_tag)
-
-    update_dep_parser = subparsers.add_parser('update-dep', help='update revision of a dependency '
-                                              'in a package')
-    update_dep_parser.add_argument('pkg', metavar='pkg[::revision]', type=parse_dependency_tag)
-
-    subparsers.add_parser('status', help='show status of workspace')
-    subparsers.add_parser('update', help='update git repos')
-
-    inspect_parser = subparsers.add_parser('inspect', help='inspect lockfile')
-    inspect_group = inspect_parser.add_mutually_exclusive_group()
-    inspect_group.add_argument('--tree', action="store_true")
-    inspect_group.add_argument('--dot', action="store_true")
-
-    fetch_scala_parser = subparsers.add_parser('fetch-scala',
-                                               help='Fetch dependencies for Scala projects')
-    fetch_scala_parser.add_argument('--jar', action='store_true', default=False,
-                                    help='download coursier jar instead of binary')
 
     args = parser.parse_args()
     if args.verbose >= 4:
@@ -164,17 +110,6 @@ def main() -> None:
 
 def parse_repo_path(args):
     return args.repo_path.split(' ') if args.repo_path else []
-
-
-def chdir(s) -> None:
-    def err(msg):
-        raise argparse.ArgumentTypeError(msg)
-    try:
-        os.chdir(s)
-    except FileNotFoundError:
-        err("'{}' path not found!".format(s))
-    except NotADirectoryError:
-        err("'{}' is not a directory!".format(s))
 
 
 def create(args) -> None:

--- a/lib/wit/parser.py
+++ b/lib/wit/parser.py
@@ -14,7 +14,7 @@ def chdir(s) -> None:
         err("'{}' is not a directory!".format(s))
 
 
-# Parse arguments. Create sub-commands for each of the modes of operation
+# ********** top-level parser **********
 parser = argparse.ArgumentParser(
     prog='wit',
     formatter_class=argparse.RawTextHelpFormatter)
@@ -32,12 +32,14 @@ parser.add_argument('--repo-path', default=os.environ.get('WIT_REPO_PATH'),
 parser.add_argument('--prepend-repo-path', default=None,
                     help='Prepend paths to the default repo search path.')
 
+# ********** command subparser aggregator **********
 subparsers = parser.add_subparsers(
                title='subcommands',
                dest='command',
                metavar='<command>',
                help='<description>')
 
+# ********** init subparser **********
 init_parser = subparsers.add_parser('init', help='create workspace')
 init_parser.add_argument('--no-update', dest='update', action='store_false',
                          help=('don\'t run update upon creating the workspace'
@@ -48,13 +50,16 @@ init_parser.add_argument('-a', '--add-pkg', metavar='repo[::revision]', action='
                          type=parse_dependency_tag, help='add an initial package')
 init_parser.add_argument('workspace_name')
 
+# ********** add-pkg subparser **********
 add_pkg_parser = subparsers.add_parser('add-pkg', help='add a package to the workspace')
 add_pkg_parser.add_argument('repo', metavar='repo[::revision]', type=parse_dependency_tag)
 
+# ********** update-pkg subparser **********
 update_pkg_parser = subparsers.add_parser('update-pkg', help='update the revision of a '
                                           'previously added package')
 update_pkg_parser.add_argument('repo', metavar='repo[::revision]', type=parse_dependency_tag)
 
+# ********** add-dep subparser **********
 add_dep_parser = subparsers.add_parser(
     name='add-dep',
     description='Adds <pkg> as a dependency to a target package determined by the current working '
@@ -66,18 +71,24 @@ add_dep_parser.add_argument(
     type=parse_dependency_tag,
     help='revision can be any git commit-ish, default is the currently checked out commit')
 
+# ********** update-dep subparser **********
 update_dep_parser = subparsers.add_parser('update-dep', help='update revision of a dependency '
                                           'in a package')
 update_dep_parser.add_argument('pkg', metavar='pkg[::revision]', type=parse_dependency_tag)
 
+# ********** status subparser **********
 subparsers.add_parser('status', help='show status of workspace')
+
+# ********** update subparser **********
 subparsers.add_parser('update', help='update git repos')
 
+# ********** inspect subparser **********
 inspect_parser = subparsers.add_parser('inspect', help='inspect lockfile')
 inspect_group = inspect_parser.add_mutually_exclusive_group()
 inspect_group.add_argument('--tree', action="store_true")
 inspect_group.add_argument('--dot', action="store_true")
 
+# ********** fetch-scala subparser **********
 fetch_scala_parser = subparsers.add_parser('fetch-scala',
                                            help='Fetch dependencies for Scala projects')
 fetch_scala_parser.add_argument('--jar', action='store_true', default=False,

--- a/lib/wit/parser.py
+++ b/lib/wit/parser.py
@@ -55,8 +55,16 @@ update_pkg_parser = subparsers.add_parser('update-pkg', help='update the revisio
                                           'previously added package')
 update_pkg_parser.add_argument('repo', metavar='repo[::revision]', type=parse_dependency_tag)
 
-add_dep_parser = subparsers.add_parser('add-dep', help='add a dependency to a package')
-add_dep_parser.add_argument('pkg', metavar='pkg[::revision]', type=parse_dependency_tag)
+add_dep_parser = subparsers.add_parser(
+    name='add-dep',
+    description='Adds <pkg> as a dependency to a target package determined by the current working '
+                'directory (which can be set by -C)',
+    help='add a dependency to a package')
+add_dep_parser.add_argument(
+    dest='pkg',
+    metavar='pkg[::revision]',
+    type=parse_dependency_tag,
+    help='revision can be any git commit-ish, default is the currently checked out commit')
 
 update_dep_parser = subparsers.add_parser('update-dep', help='update revision of a dependency '
                                           'in a package')

--- a/lib/wit/parser.py
+++ b/lib/wit/parser.py
@@ -15,7 +15,9 @@ def chdir(s) -> None:
 
 
 # Parse arguments. Create sub-commands for each of the modes of operation
-parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+parser = argparse.ArgumentParser(
+    prog='wit',
+    formatter_class=argparse.RawTextHelpFormatter)
 parser.add_argument('-v', '--verbose', action='count', default=0,
                     help='''Specify level of verbosity
 -v:    verbose
@@ -30,7 +32,11 @@ parser.add_argument('--repo-path', default=os.environ.get('WIT_REPO_PATH'),
 parser.add_argument('--prepend-repo-path', default=None,
                     help='Prepend paths to the default repo search path.')
 
-subparsers = parser.add_subparsers(dest='command', help='sub-command help')
+subparsers = parser.add_subparsers(
+               title='subcommands',
+               dest='command',
+               metavar='<command>',
+               help='<description>')
 
 init_parser = subparsers.add_parser('init', help='create workspace')
 init_parser.add_argument('--no-update', dest='update', action='store_false',

--- a/lib/wit/parser.py
+++ b/lib/wit/parser.py
@@ -1,0 +1,70 @@
+import argparse
+import os
+from .dependency import parse_dependency_tag
+
+
+def chdir(s) -> None:
+    def err(msg):
+        raise argparse.ArgumentTypeError(msg)
+    try:
+        os.chdir(s)
+    except FileNotFoundError:
+        err("'{}' path not found!".format(s))
+    except NotADirectoryError:
+        err("'{}' is not a directory!".format(s))
+
+
+# Parse arguments. Create sub-commands for each of the modes of operation
+parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+parser.add_argument('-v', '--verbose', action='count', default=0,
+                    help='''Specify level of verbosity
+-v:    verbose
+-vv:   debug
+-vvv:  trace
+-vvvv: spam
+''')
+parser.add_argument('--version', action='store_true', help='Print wit version')
+parser.add_argument('-C', dest='cwd', type=chdir, metavar='path', help='Run in given path')
+parser.add_argument('--repo-path', default=os.environ.get('WIT_REPO_PATH'),
+                    help='Specify alternative paths to look for packages')
+parser.add_argument('--prepend-repo-path', default=None,
+                    help='Prepend paths to the default repo search path.')
+
+subparsers = parser.add_subparsers(dest='command', help='sub-command help')
+
+init_parser = subparsers.add_parser('init', help='create workspace')
+init_parser.add_argument('--no-update', dest='update', action='store_false',
+                         help=('don\'t run update upon creating the workspace'
+                               ' (implies --no-fetch-scala)'))
+init_parser.add_argument('--no-fetch-scala', dest='fetch_scala', action='store_false',
+                         help='don\'t run fetch-scala upon creating the workspace')
+init_parser.add_argument('-a', '--add-pkg', metavar='repo[::revision]', action='append',
+                         type=parse_dependency_tag, help='add an initial package')
+init_parser.add_argument('workspace_name')
+
+add_pkg_parser = subparsers.add_parser('add-pkg', help='add a package to the workspace')
+add_pkg_parser.add_argument('repo', metavar='repo[::revision]', type=parse_dependency_tag)
+
+update_pkg_parser = subparsers.add_parser('update-pkg', help='update the revision of a '
+                                          'previously added package')
+update_pkg_parser.add_argument('repo', metavar='repo[::revision]', type=parse_dependency_tag)
+
+add_dep_parser = subparsers.add_parser('add-dep', help='add a dependency to a package')
+add_dep_parser.add_argument('pkg', metavar='pkg[::revision]', type=parse_dependency_tag)
+
+update_dep_parser = subparsers.add_parser('update-dep', help='update revision of a dependency '
+                                          'in a package')
+update_dep_parser.add_argument('pkg', metavar='pkg[::revision]', type=parse_dependency_tag)
+
+subparsers.add_parser('status', help='show status of workspace')
+subparsers.add_parser('update', help='update git repos')
+
+inspect_parser = subparsers.add_parser('inspect', help='inspect lockfile')
+inspect_group = inspect_parser.add_mutually_exclusive_group()
+inspect_group.add_argument('--tree', action="store_true")
+inspect_group.add_argument('--dot', action="store_true")
+
+fetch_scala_parser = subparsers.add_parser('fetch-scala',
+                                           help='Fetch dependencies for Scala projects')
+fetch_scala_parser.add_argument('--jar', action='store_true', default=False,
+                                help='download coursier jar instead of binary')


### PR DESCRIPTION
Including @mwachs5 as a reviewer because the main purpose of this PR is improving error messages that hopefully will help her and other users.

Each commit is meaningful and I have questions on all of them (except the first)

1. Split command-line parser into different file

This one is simple, but it just splits out the exact code from `main.py` to `parser.py`. The one thing I don't like is that everything is top-level and mutable, I'd rather have some immutable representation of the parser and each of the subparsers, but that seems pretty difficult to do, so this will do for now I guess.

2. Improve parser help text

This improves how subcommands are specified. This changes it from:
```
$ wit -h
usage: __main__.py [-h] [-v] [--version] [-C path] [--repo-path REPO_PATH]
                   [--prepend-repo-path PREPEND_REPO_PATH]
                   {init,add-pkg,update-pkg,add-dep,update-dep,status,update,inspect,fetch-scala}
                   ...

positional arguments:
  {init,add-pkg,update-pkg,add-dep,update-dep,status,update,inspect,fetch-scala}
                        sub-command help
    init                create workspace
    add-pkg             add a package to the workspace
    update-pkg          update the revision of a previously added package
    add-dep             add a dependency to a package
    update-dep          update revision of a dependency in a package
    status              show status of workspace
    update              update git repos
    inspect             inspect lockfile
    fetch-scala         Fetch dependencies for Scala projects

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         Specify level of verbosity
                        -v:    verbose
                        -vv:   debug
                        -vvv:  trace
                        -vvvv: spam
  --version             Print wit version
  -C path               Run in given path
  --repo-path REPO_PATH
                        Specify alternative paths to look for packages
  --prepend-repo-path PREPEND_REPO_PATH
                        Prepend paths to the default repo search path.
```

To:
```
$ wit -h
usage: wit [-h] [-v] [--version] [-C path] [--repo-path REPO_PATH]
           [--prepend-repo-path PREPEND_REPO_PATH]
           <command> ...

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         Specify level of verbosity
                        -v:    verbose
                        -vv:   debug
                        -vvv:  trace
                        -vvvv: spam
  --version             Print wit version
  -C path               Run in given path
  --repo-path REPO_PATH
                        Specify alternative paths to look for packages
  --prepend-repo-path PREPEND_REPO_PATH
                        Prepend paths to the default repo search path.

subcommands:
  <command>             <description>
    init                create workspace
    add-pkg             add a package to the workspace
    update-pkg          update the revision of a previously added package
    add-dep             add a dependency to a package
    update-dep          update revision of a dependency in a package
    status              show status of workspace
    update              update git repos
    inspect             inspect lockfile
    fetch-scala         Fetch dependencies for Scala projects
```

3. Improve help text for add_dep_parser

Changes it from:
```
$ wit add-dep -h
usage: __main__.py add-dep [-h] pkg[::revision]

positional arguments:
  pkg[::revision]

optional arguments:
  -h, --help       show this help message and exit
```
To:
```
$ wit add-dep -h
usage: wit add-dep [-h] pkg[::revision]

Adds <pkg> as a dependency to a target package determined by the current
working directory (which can be set by -C)

positional arguments:
  pkg[::revision]  revision can be any git commit object, default is currently
                   checked out commit

optional arguments:
  -h, --help       show this help message and exit
```

4. Use add_dep_parser for help instead of custom error

Related to https://github.com/sifive/wit/pull/187, this uses the help text for the add_dep_parser instead of the text we added in #187, it's a bit DRY-er which is nice and could set a pattern for future similar error messages.

Before:
```
$ wit add-dep foo
[ERROR] add-dep must be run inside of a package, not the workspace root.
  A dependency is added to the package determined by the current working directory,
  which can also be set by -C.
```
After:
```
$ wit add-dep foo
[ERROR] add-dep must be run inside of a package, not the workspace root.

usage: wit add-dep [-h] pkg[::revision]

Adds <pkg> as a dependency to a target package determined by the current
working directory (which can be set by -C)

positional arguments:
  pkg[::revision]  revision can be any git commit object, default is currently
                   checked out commit

optional arguments:
  -h, --help       show this help message and exit
```

Perhaps this is Much Ado About Nothing but I'm looking for patterns to apply going forward, and I think there are some good ideas here. I would just like to check before applying these ideas any further.