### PR TITLE
Add a 'foreach' command

### DIFF
--- a/lib/wit/parser.py
+++ b/lib/wit/parser.py
@@ -99,6 +99,31 @@ inspect_group = inspect_parser.add_mutually_exclusive_group()
 inspect_group.add_argument('--tree', action="store_true")
 inspect_group.add_argument('--dot', action="store_true")
 
+# ********** foreach subparser **********
+foreach_parser = subparsers.add_parser(
+    'foreach',
+    help='perform a command in each repository directory',
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description="""
+Perform a command in each repository directory.
+The repository list is created by reading records contained in 'wit-lock.json'.
+
+Any options, such as --continue-on-fail must be specified before the command.
+
+Wit sets the following environment variables for each invocation of the command:
+    WIT_REPO_NAME    repository name
+    WIT_REPO_PATH    path to repository
+    WIT_LOCK_SOURCE  initial source location of repository
+    WIT_LOCK_COMMIT  commit recorded in lockfile, actual repository contents could be different
+    WIT_WORKSPACE    path to root of wit workspace""")
+
+foreach_parser.add_argument('--continue-on-fail', action='store_true',
+                            help='run the command in each repository regardless of failures')
+
+# 'cmd' and 'args' eventually become one list, but this forces at least one input string
+foreach_parser.add_argument('cmd', help='command to run in each repository')
+foreach_parser.add_argument('args', nargs=argparse.REMAINDER, help='arguments for the command')
+
 # ********** fetch-scala subparser **********
 fetch_scala_parser = subparsers.add_parser('fetch-scala',
                                            help='Fetch dependencies for Scala projects')

--- a/t/wit_foreach.t
+++ b/t/wit_foreach.t
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+. $(dirname $0)/test_util.sh
+
+prereq on
+
+# make 2 repositories
+make_repo 'foo'
+foo_dir=$PWD/foo
+make_repo 'baa'
+baa_dir=$PWD/baa
+
+# create wit workspace
+wit init myws -a $foo_dir -a $baa_dir
+cd myws
+
+prereq off
+
+output=$(wit foreach --quiet 'echo $WIT_REPO_NAME' | tr '\n' ' ')
+expected='baa foo '
+check "wit foreach should know the repository names" $([ "$output" = "$expected" ])
+
+
+report
+finish


### PR DESCRIPTION
This is inspired by `git submodule foreach` [[link](https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt-foreach--recursiveltcommandgt)]

```
$ wit foreach --help
usage: wit foreach [-h] [--quiet] [--continue-on-fail] cmd ...

Perform a command in each repository directory.
The repository list is created by reading records contained in 'wit-lock.json'.

If used, options --quiet and --continue-on-fail must be specified before the command.

The following environment variables are exposed to the command:
    WIT_REPO_NAME    repository name
    WIT_REPO_PATH    path to repository
    WIT_LOCK_SOURCE  inital source location of repository
    WIT_LOCK_COMMIT  commit recorded in lockfile, actual repository contents could be different
    WIT_WORKSPACE    path to root of wit workspace

positional arguments:
  cmd                 command to run in each repository
  args                arguments for the command

optional arguments:
  -h, --help          show this help message and exit
  --quiet             Supress printed lines indicating working repository
  --continue-on-fail  run the command in each repository regardless of
                      failures
```

```
$ wit foreach 'echo $WIT_REPO_NAME; git rev-parse HEAD'
Entering 'repo1'
repo1
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
Entering 'repo2'
repo2
bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
```