### PR TITLE
Improve resolution warning for wit-manifest from commit instead of disk

### DIFF
--- a/lib/wit/workspace.py
+++ b/lib/wit/workspace.py
@@ -168,8 +168,8 @@ class WorkSpace:
             used_commit = pkg.revision
             fs_commit = pkg.repo.get_commit('HEAD')
             if used_commit != fs_commit:
-                log.warn("using '{}' manifest instead of checked-out version of '{}'".format(
-                    pkg.id(), pkg.name))
+                log.warn("using '{}' manifest instead of currently checked-out version in '{}'"
+                         .format(pkg.id(), pkg.name))
                 continue
 
             if pkg.repo.modified_manifest():

--- a/t/warn_manifest_changes.t
+++ b/t/warn_manifest_changes.t
@@ -33,14 +33,14 @@ wit add-pkg $foo_dir
 output=$(wit update)
 echo $output | grep "disregarding uncommitted changes"
 check "initial wit update should not log uncommitted manifest warnings" [ $? -ne 0 ]
-echo $output | grep "manifest instead of checked-out version"
+echo $output | grep "manifest instead of currently checked-out version"
 check "initial wit update should not log different manifest warnings" [ $? -ne 0 ]
 
 rm foo/wit-manifest.json
 output=$(wit update)
 echo $output | grep "disregarding uncommitted changes"
 check "initial wit update should log uncommitted manifest warnings" [ $? -eq 0 ]
-echo $output | grep "manifest instead of checked-out version"
+echo $output | grep "manifest instead of currently checked-out version"
 check "initial wit update should not log different manifest warnings" [ $? -ne 0 ]
 
 git -C foo add -A
@@ -48,7 +48,7 @@ git -C foo commit -m "remove manifest"
 output=$(wit update)
 echo $output | grep "disregarding uncommitted changes"
 check "initial wit update should not log uncommitted manifest warnings" [ $? -ne 0 ]
-echo $output | grep "manifest instead of checked-out version"
+echo $output | grep "manifest instead of currently checked-out version"
 check "initial wit update should log different manifest warnings" [ $? -eq 0 ]
 
 set +x


### PR DESCRIPTION
Concrete proposal for improvement to warning. The idea is that it's as clear as possible to the user that the Wit resolution algorithm picks what `wit-manifest.json`s are being used and they may not match the ones currently checked out on disk.

I got these messages by creating a workspace for https://github.com/sifive/example-scala-wake-project and then checking out `master` of it's dependency, `api-scala-sifive`. Wit correctly tells me that it's ignoring the `wit-manifest.json` that's currently on disk for `api-scala-sifive`, instead using the one from the commit that is pointed to by `example-scala-wake-project`

#### Wit `v0.12.0` message
```
$ wit status
Clean packages:
    example-scala-wake-project
Dirty packages:
    api-scala-sifive (new commits)
[WARNING] using 'api-scala-sifive::cade56f' manifest instead of checked-out version of 'api-scala-sifive'
api-scala-sifive (will be checked out to cade56f)
```

#### Currently propose small change
`instead of checked-out version of <package>` -> `currently checked-out version in <package>`
```
$ wit status
Clean packages:
    example-scala-wake-project
Dirty packages:
    api-scala-sifive (new commits)
[WARNING] using 'api-scala-sifive::cade56f' manifest instead of currently checked-out version in 'api-scala-sifive'
api-scala-sifive (will be checked out to cade56f)
```

#### Alternative proposal
```
$ wit status
Clean packages:
    example-scala-wake-project
Dirty packages:
    api-scala-sifive (new commits)
[WARNING] using wit-manifest at 'api-scala-sifive::cade56f' instead of 'api-scala-sifive'/wit-manifest.json' in current wit workspace
api-scala-sifive (will be checked out to cade56f)
````

