### PR TITLE
setup.py for pip install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 install_root := $(PREFIX)
-version := $(shell ./wit --version | sed 's/^wit //')
+version := $(shell cat lib/wit/version.py | grep -o '[.0-9]*')
 install_dir := $(install_root)/$(version)
 
 install:
 	mkdir -p $(install_dir)
-	echo $(version) > $(install_dir)/__version__
 	cat .gitignore > .rsyncignore
 	git ls-files -o >> .rsyncignore
 	rsync -ar --include=wit --include='*.py' --exclude-from=.rsyncignore --exclude='actions/' --exclude='t/' --exclude='__pycache__/' --exclude='.*' --exclude='mypy.ini' --exclude='Makefile' . $(install_dir)

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -1,0 +1,19 @@
+import setuptools
+
+version = {}
+with open("wit/version.py") as fd:
+    exec(fd.read(), version)
+
+setuptools.setup(
+    name='wit-sifive',
+    version=version['__version__'],
+    description="Wit: Workspace Integration Tool",
+    long_description="See README.md at https://github.com/sifive/wit/",
+    author='SiFive',
+    author_email='',
+    url='www.github.com/sifive/wit',
+    packages=["wit"],
+    entry_points={'console_scripts': ['wit=wit.main:main']},
+    python_requires='>=3.5',
+    classifiers=["License :: OSI Approved :: Apache Software License"],
+)

--- a/lib/wit/version.py
+++ b/lib/wit/version.py
@@ -1,0 +1,2 @@
+# This is the version reported by 'wit --version' when running outside a git repository
+__version__ = "0.12.0"

--- a/t/install.t
+++ b/t/install.t
@@ -11,8 +11,8 @@ wit_exe=$(find $install_dir -name 'wit' -type f)
 echo $wit_exe
 check "We should find the wit executable" [ ! -z "$wit_exe" ]
 
-$wit_exe -vvvv --version | grep -q 'Version as read from'
-check "Wit logging should tell us it read from __version__" [ $? -eq 0 ]
+$wit_exe --version
+check "Wit --version should execute" [ $? -eq 0 ]
 
 report
 finish


### PR DESCRIPTION
Add a `setup.py` so that we can `pip install`.
This has an earlier PR https://github.com/sifive/wit/pull/206 by @robertd-sifive that I leaned on heavily as I'm not very familiar with python packaging, but I had some enthusiasm to try get the ball rolling on this again.

The 0.12.0 version is just a placeholder version until we decided to actually publish to PyPi