### PR TITLE
Error on duplicate repo entries in manifest

### DIFF
--- a/lib/wit/gitrepo.py
+++ b/lib/wit/gitrepo.py
@@ -256,7 +256,7 @@ class GitRepo:
             log.debug("No dependency file found in repo [{}:{}]".format(revision,
                       self.path))
         json_content = [] if proc.returncode else json.loads(proc.stdout)
-        return manifest.Manifest.process_manifest(json_content)
+        return manifest.Manifest.process_manifest(json_content, self.name)
 
     def checkout(self, revision):
         wanted_hash = self.get_commit(revision)

--- a/lib/wit/manifest.py
+++ b/lib/wit/manifest.py
@@ -64,8 +64,8 @@ class Manifest:
         # Fail if there are dependencies with the same name
         dep_names = [dep['name'] for dep in json_content]
         if len(dep_names) != len(set(dep_names)):
-            dup = [x for x in dep_names if dep_names.count(x) > 1][0]
-            raise Exception("Two dependencies have the same name in {}: {}".format(location, dup))
+            dup = set([x for x in dep_names if dep_names.count(x) > 1])
+            raise Exception("Two dependencies have the same name in '{}': {}".format(location, dup))
 
         # import here to prevent circular dependency
         from .dependency import manifest_item_to_dep


### PR DESCRIPTION
While looking at how to make `wit init` more parallel, I found a repo that has duplicate entries for a single repository at different commits: https://github.com/sifive/freedom-e-sdk/pull/463

This diff make it an error to do so.