### PR TITLE
Partially parallel 'wit init'

### DIFF
--- a/lib/wit/gitrepo.py
+++ b/lib/wit/gitrepo.py
@@ -78,7 +78,6 @@ class GitRepo:
     def clone(self, source, name):
         assert not GitRepo.is_git_repo(self.path), \
             "Trying to clone and checkout into existing git repo!"
-        log.info('Cloning {}...'.format(self.name))
 
         cmd = ["clone", *self._git_reference_options(), "--no-checkout", source, str(self.path)]
         proc = self._git_command(*cmd, working_dir=str(self.path.parent))
@@ -89,6 +88,7 @@ class GitRepo:
                 raise BadSource(name, source)
             else:
                 raise
+        log.info('Cloned {}'.format(self.name))
 
     def _git_reference_options(self):
         """

--- a/lib/wit/main.py
+++ b/lib/wit/main.py
@@ -68,7 +68,7 @@ def main() -> None:
             # These commands assume the workspace already exists. Error out if the
             # workspace cannot be found.
             try:
-                ws = WorkSpace.find(Path.cwd(), parse_repo_path(args))
+                ws = WorkSpace.find(Path.cwd(), parse_repo_path(args), args.jobs)
 
             except FileNotFoundError as e:
                 log.error("Unable to find workspace root [{}]. Cannot continue.".format(e))
@@ -146,7 +146,7 @@ def create(args) -> None:
     else:
         dependencies = args.add_pkg
 
-    ws = WorkSpace.create(args.workspace_name, parse_repo_path(args))
+    ws = WorkSpace.create(args.workspace_name, parse_repo_path(args), args.jobs)
     for dep in dependencies:
         ws.add_dependency(dep)
 

--- a/lib/wit/parser.py
+++ b/lib/wit/parser.py
@@ -2,6 +2,9 @@ import argparse
 import os
 from .dependency import parse_dependency_tag
 
+# default max parallel git clones possible by 'init' or 'update'
+_max_clone_jobs = 64
+
 
 def chdir(s) -> None:
     def err(msg):
@@ -31,6 +34,9 @@ parser.add_argument('--repo-path', default=os.environ.get('WIT_REPO_PATH'),
                     help='Specify alternative paths to look for packages')
 parser.add_argument('--prepend-repo-path', default=None,
                     help='Prepend paths to the default repo search path.')
+parser.add_argument('-j', '--max-parallel-clones', dest='jobs', default=_max_clone_jobs, type=int,
+                    help="Max quantity of 'git clone' to run in parallel. "
+                    "Default is '{}'. Set to '1' for serial cloning.".format(_max_clone_jobs))
 
 # ********** command subparser aggregator **********
 subparsers = parser.add_subparsers(

--- a/lib/wit/workspace.py
+++ b/lib/wit/workspace.py
@@ -60,11 +60,12 @@ class WorkSpace:
     MANIFEST = "wit-workspace.json"
     LOCK = "wit-lock.json"
 
-    def __init__(self, root, repo_paths):
+    def __init__(self, root, repo_paths, jobs):
         self.root = root
         self.repo_paths = repo_paths
         self.manifest = self._load_manifest()
         self.lock = self._load_lockfile()
+        self.jobs = jobs
 
     def id(self):
         return "[root]"
@@ -73,7 +74,7 @@ class WorkSpace:
         return "root"
 
     @classmethod
-    def create(cls, name, repo_paths):
+    def create(cls, name, repo_paths, jobs):
         """Create a wit workspace on disk with the appropriate json files"""
         root = Path.cwd() / name
         manifest_path = cls._manifest_path(root)
@@ -104,7 +105,7 @@ class WorkSpace:
         lockfile = LockFile([])
         lockfile.write(cls._lockfile_path(root))
 
-        return WorkSpace(root, repo_paths)
+        return WorkSpace(root, repo_paths, jobs)
 
     def _load_manifest(self):
         return Manifest.read_manifest(self.manifest_path())
@@ -127,21 +128,23 @@ class WorkSpace:
         return WorkSpace._lockfile_path(self.root)
 
     @staticmethod
-    def find(start, repo_paths):
+    def find(start, repo_paths, jobs):
         cwd = start.resolve()
         for p in ([cwd] + list(cwd.parents)):
             manifest_path = WorkSpace._manifest_path(p)
             log.debug("Checking [{}]".format(manifest_path))
             if Path(manifest_path).is_file():
                 log.debug("Found workspace at [{}]".format(p))
-                return WorkSpace(p, repo_paths)
+                return WorkSpace(p, repo_paths, jobs)
 
         raise FileNotFoundError("Couldn't find workspace file")
 
     def resolve(self, download=False):
-        source_map, packages, queue, errors = \
-            self.resolve_deps(self.root, self.repo_paths, download, {}, {}, [], [])
+        source_map, packages, queue = \
+            self.resolve_deps(self.root, self.repo_paths, download, {}, {}, [])
 
+        errors = list()
+        dep_errors = list()
         while queue:
             commit_time, dep = queue.pop()
             log.debug("{} {}".format(commit_time, dep))
@@ -157,9 +160,9 @@ class WorkSpace:
             packages[dep.name].revision = dep.resolved_rev()
             packages[dep.name].set_source(dep.source)
 
-            source_map, packages, queue, errors = \
-                dep.resolve_deps(self.root, self.repo_paths, download,
-                                 source_map, packages, queue, errors)
+            source_map, packages, queue, dep_errors = \
+                dep.resolve_deps(self.root, self.repo_paths, download, source_map,
+                                 packages, queue, self.jobs)
 
         for pkg in packages.values():
             if not pkg.repo or pkg.repo.path.parts[-2] == '.wit':
@@ -175,9 +178,9 @@ class WorkSpace:
             if pkg.repo.modified_manifest():
                 log.warn("disregarding uncommitted changes to the '{}' manifest".format(pkg.name))
 
-        return packages, errors
+        return packages, errors + dep_errors
 
-    def resolve_deps(self, wsroot, repo_paths, download, source_map, packages, queue, errors):
+    def resolve_deps(self, wsroot, repo_paths, download, source_map, packages, queue):
         source_map = source_map.copy()
         queue = queue.copy()
         for dep in self.manifest.dependencies:
@@ -192,7 +195,7 @@ class WorkSpace:
 
         queue.sort(key=lambda tup: tup[0])
 
-        return source_map, packages, queue, []
+        return source_map, packages, queue
 
     def checkout(self, packages):
         lock_packages = []


### PR DESCRIPTION
This adds some amount of parallelism to the `wit init`'s git clone process.

When a package (or dependency) has multiple dependencies, those dependencies are now downloaded/cloned as a batch in parallel.
Going down one level you will create more batches of parallel clones, but only _1 batch_ will run at a time. A batch is defined as the contents of a `wit-manifest.json`.

This isn't the most parallel it could possibly be, but was practical to implement given my current understanding of the codebase, and should speed things up a little for everyone without any extra configuration.

Notes for the times I recorded:
- home network connection with no other jobs running on machine
- the initial (-a) package causes a lot of dependencies
- reference and partial clone use `wit init`
- reference requires WIT_WORKSPACE_REFERENCE to point at an earlier workspace
- partial parallel needs no extra configuration
- restore uses `wit restore`
- restore requires another workspace to point at to resolve the wit-lock.json
- the lock file used for restore is the same as generated by the other wit init runs

| [--reference](https://github.com/sifive/wit/pull/218)  | [partial-parallel](https://github.com/sifive/wit/pull/222) | [restore](https://github.com/sifive/wit/pull/211/) | Time |
| ------------- | ------------- | ------------- | ------------- |
| ✕  | ✕  | ✕ | 7m07s |
| ✅  | ✕  | ✕ | 4m13s |
| ✕  | ✅  | ✕ | 3m41s |
| ✅  | ✅  | ✕ | 1m09s|
| ✕  | ✕  | ✅ | 2m59s|
| ✅  | ✕  | ✅ | 0m13s|