### PR TITLE
Add /bin/bash to github actions docker container

### DIFF
--- a/docker/wit.Dockerfile
+++ b/docker/wit.Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-alpine
 COPY ./lib /wit/
 WORKDIR /wit
 
-RUN apk add git --no-cache && \
+RUN apk add git bash --no-cache && \
     python3 -m pip install .
 
 CMD /bin/sh


### PR DESCRIPTION
Since we moved our actions docker container to alpine linux, we should use /bin/sh instead of bash