### PR TITLE
Passing tests should be quiet

### DIFF
--- a/t/test_all.sh
+++ b/t/test_all.sh
@@ -32,7 +32,6 @@ declare -A test_results
 pass=0
 fail=0
 for test_path in $test_root/*.t; do
-    echo "====================================================="
     cd $test_dir
     test_file=$(basename $test_path)
     test_name="${test_file%%.*}"
@@ -41,22 +40,26 @@ for test_path in $test_root/*.t; do
     then continue
     fi
 
-    echo "Running test [$test_name]"
-    mkdir $test_name
-    cd $test_name
+    printf "Running test [$test_name]: "
+    output=$({
+        mkdir $test_name
+        cd $test_name
+        $test_path
+    } 2>&1 )
 
-    $test_path
     if [ $? -eq 0 ]; then
         test_results["$test_name"]="PASS"
         touch "PASS"
         ((pass++))
+        echo "${test_results[$test_name]}";
     else
         test_results["$test_name"]="FAIL"
         touch "FAIL"
         ((fail++))
         test_result=1
+        echo "${test_results[$test_name]}";
+        echo "$output"
     fi
-    echo -e "\033[1K\033[1G${test_results[$test_name]} - ${test_name}";
 done
 
 echo


### PR DESCRIPTION
Tests that pass write a lot of text to the console, 
instead only print the commands within the test if we get an error

An example of the new output, with a fake error included
```
$ make test-all
flake8
mypy lib/wit/*.py
Success: no issues found in 15 source files
./t/test_all.sh
Running [1] tests in parallel.
Running with wit: /home/matthewc/work/wit/wit
Running tests in /home/matthewc/work/wit/test.2020-05-13T17-19-30
Running test [bad_source]: PASS
Running test [install]: PASS
Running test [repo_path_addpkg]: FAIL
Running with wit: /home/matthewc/work/wit/wit
Initialized empty Git repository in /home/matthewc/work/wit/test.2020-05-13T17-19-30/repo_path_addpkg/foo/.git/
[master (root-commit) 7ee7adb] commit1
 1 file changed, 1 insertion(+)
 create mode 100644 file
Initialized empty Git repository in /home/matthewc/work/wit/test.2020-05-13T17-19-30/repo_path_addpkg/foo2/.git/
[master (root-commit) 7ee7adb] commit1
 1 file changed, 1 insertion(+)
 create mode 100644 file
Initialized empty Git repository in /home/matthewc/work/wit/test.2020-05-13T17-19-30/repo_path_addpkg/foo3/.git/
[master (root-commit) 7ee7adb] commit1
 1 file changed, 1 insertion(+)
 create mode 100644 file
Initialized empty Git repository in /home/matthewc/work/wit/test.2020-05-13T17-19-30/repo_path_addpkg/bar/.git/
[master (root-commit) 69ba604] commit1
 1 file changed, 17 insertions(+)
 create mode 100644 wit-manifest.json
+ echo artificial failure message
artificial failure message
+ exit 1
Running test [repo_path_nosource]: PASS
Running test [repo_path_relative_root_pkg]: PASS
Running test [repo_path]: PASS
Running test [sources_conflict_resolvable]: PASS
Running test [sources_conflict_unresolvable]: PASS
...
Running test [wit_update_pkg_fetch]: PASS
Running test [wit_update_pkg_not_in_workspace]: PASS
Running test [wit_update_pkg]: PASS
Running test [wit_update]: PASS

Results:
Passing: 35
Failing: 1
```