### PR TITLE
Use same json format for lock/manifest/workspace

### DIFF
--- a/lib/wit/gitrepo.py
+++ b/lib/wit/gitrepo.py
@@ -3,14 +3,13 @@
 import subprocess
 from pathlib import Path
 from pprint import pformat
-import json
 import re
-from . import manifest
 from .common import WitUserError
 from .witlogger import getLogger
-from typing import Set  # noqa: F401
+from typing import List, Set  # noqa: F401
 from functools import lru_cache
 from .env import git_reference_workspace
+from .repo_entries import RepoEntry, RepoEntries
 
 log = getLogger()
 
@@ -242,21 +241,14 @@ class GitRepo:
                                  current or self.get_head_commit())
         return proc.returncode == 0
 
-    def read_manifest(self) -> manifest.Manifest:
-        mpath = self.manifest_path()
-        return manifest.Manifest.read_manifest(mpath, safe=True)
-
-    def write_manifest(self, manifest) -> None:
-        mpath = self.manifest_path()
-        manifest.write(mpath)
-
-    def read_manifest_from_commit(self, revision) -> manifest.Manifest:
-        proc = self._git_command("show", "{}:{}".format(revision, GitRepo.PKG_DEPENDENCY_FILE))
+    def repo_entries_from_commit(self, revision) -> List[RepoEntry]:
+        where = "{}:{}".format(revision, GitRepo.PKG_DEPENDENCY_FILE)
+        proc = self._git_command("show", where)
         if proc.returncode:
             log.debug("No dependency file found in repo [{}:{}]".format(revision,
                       self.path))
-        json_content = [] if proc.returncode else json.loads(proc.stdout)
-        return manifest.Manifest.process_manifest(json_content, self.name)
+            return []
+        return RepoEntries.parse_repo_entries(proc.stdout, "{}:{}".format(self.path, where))
 
     def checkout(self, revision):
         wanted_hash = self.get_commit(revision)

--- a/lib/wit/lock.py
+++ b/lib/wit/lock.py
@@ -2,7 +2,6 @@
 
 import json
 from .gitrepo import GitRepo
-from collections import OrderedDict
 from typing import Optional
 from .witlogger import getLogger
 from .package import Package
@@ -35,7 +34,7 @@ class LockFile:
 
     def write(self, path):
         log.debug("Writing lock file to {}".format(path))
-        contents = OrderedDict((p.name, p.manifest()) for p in self.packages)
+        contents = [p.manifest() for p in self.packages]
         manifest_json = json.dumps(contents, sort_keys=True, indent=4) + '\n'
         path.write_text(manifest_json)
 
@@ -47,7 +46,7 @@ class LockFile:
 
     @staticmethod
     def process(content):
-        pkgs = [lockfile_item_to_pkg(x) for _, x in content.items()]
+        pkgs = [lockfile_item_to_pkg(x) for x in content]
         return LockFile(pkgs)
 
 

--- a/lib/wit/lock.py
+++ b/lib/wit/lock.py
@@ -1,17 +1,13 @@
 #!/usr/bin/env python3
 
-import json
 from .gitrepo import GitRepo
 from typing import Optional
 from .witlogger import getLogger
-from .package import Package
+from .repo_entries import RepoEntries
 
 log = getLogger()
 
 
-# TODO
-# Should we use different datastructures?
-# The JSON file format slightly differs from manifest, why?
 class LockFile:
     """
     Common class for the description of package dependencies and a workspace
@@ -34,29 +30,16 @@ class LockFile:
 
     def write(self, path):
         log.debug("Writing lock file to {}".format(path))
-        contents = [p.manifest() for p in self.packages]
-        manifest_json = json.dumps(contents, sort_keys=True, indent=4) + '\n'
-        path.write_text(manifest_json)
+        contents = [p.to_repo_entry() for p in self.packages]
+        RepoEntries.write_repo_entries(path, contents)
 
     @staticmethod
     def read(path):
         log.debug("Reading lock file from {}".format(path))
-        content = json.loads(path.read_text())
-        return LockFile.process(content)
-
-    @staticmethod
-    def process(content):
-        pkgs = [lockfile_item_to_pkg(x) for x in content]
-        return LockFile(pkgs)
+        from .package import Package
+        return LockFile([Package.from_repo_entry(x) for x in RepoEntries.read_repo_entries(path)])
 
 
 if __name__ == '__main__':
     import doctest
     doctest.testmod()
-
-
-def lockfile_item_to_pkg(item):
-    pkg = Package(item['name'], [])
-    pkg.set_source(item['source'])
-    pkg.revision = item['commit']
-    return pkg

--- a/lib/wit/repo_entries.py
+++ b/lib/wit/repo_entries.py
@@ -1,0 +1,91 @@
+import json
+from pathlib import Path
+from typing import List
+
+
+# The intent of RepoEntry and List[RepoEntry] is that no other
+# parts of the codebase knows that json is used as the on-disk format, or know
+# any of the field names.
+
+
+class RepoEntry:
+
+    def __init__(self, workspace_name, revision, remote_path, message=None):
+        # The path to checkout at within the workspace.
+        # JSON field name is 'name'.
+        self.workspace_name = workspace_name
+
+        # Desired revision that exists in the history of the below remote.
+        # JSON field name is 'commit'
+        self.revision = revision
+
+        # Name of the branch that the revision is required to be a member of.
+        # Optional. JSON field name is 'branch'
+        # TODO add this
+        # self.branch = branch
+
+        # Url (or local fs path) for git to clone/fetch/push.
+        # JSON field name is 'source'
+        self.remote_path = remote_path
+
+        # Name assigned to the remote within the repository checkout.
+        # Optional. JSON field name is 'remote_name'
+        # TODO add this
+        # self.remote_name = remote_name
+
+        # A comment to leave in any serialized artifacts.
+        # Optional. JSON field name is '//'
+        self.message = message
+
+    def _serialized_names(self) -> dict:
+        d = {
+            "name": self.workspace_name,
+            "commit": self.revision,
+            "source": self.remote_path,
+        }
+        if self.message and len(self.message) > 0:
+            d["//"] = self.message
+        return d
+
+    @staticmethod
+    def _from_serialized_names(data: dict):
+        return RepoEntry(data["name"],
+                         data["commit"],
+                         data.get("source"),  # 'repo path' cli option needs this optional
+                         data.get("//"))  # optional
+
+    def __repr__(self):
+        return str(self.__dict__)
+
+
+# Utilities for List[RepoEntry]
+class RepoEntries:
+    @staticmethod
+    def parse_repo_entries(text: str, where: str) -> List[RepoEntry]:
+        try:
+            fromtext = json.loads(text)
+        except json.JSONDecodeError as e:
+            raise Exception("Failed to parse json in {}: {}".format(where, e.msg))
+
+        entries = []
+        for entry in fromtext:
+            entries.append(RepoEntry._from_serialized_names(entry))
+
+        # Check for duplicates
+        names = [entry.workspace_name for entry in entries]
+        if len(names) != len(set(names)):
+            dup = set([x for x in names if names.count(x) > 1])
+            raise Exception("Two repositories have the same name in {}: {}".format(where, dup))
+
+        return entries
+
+    @staticmethod
+    def write_repo_entries(path: Path, entries: List[RepoEntry]):
+        dict_data = [e._serialized_names() for e in entries]
+        json_data = json.dumps(dict_data, sort_keys=True, indent=4) + "\n"
+        path.write_text(json_data)
+
+    @staticmethod
+    def read_repo_entries(path: Path) -> List[RepoEntry]:
+        text = path.read_text()
+        return RepoEntries.parse_repo_entries(text, str(path))

--- a/t/repo_path.t
+++ b/t/repo_path.t
@@ -56,10 +56,10 @@ check "foo should be pulled in as a dependency of bar" [ -d foo ]
 foo_ws_commit=$(git -C foo rev-parse HEAD)
 check "foo commit should match the dependency in bar" [ "$foo_ws_commit" = "$foo_commit" ]
 
-foo_lock_commit=$(jq -r '.foo.commit' wit-lock.json)
+foo_lock_commit=$(jq -r '.[] | select(.name=="foo") | .commit' wit-lock.json)
 check "ws-lock.json should contain correct foo commit" [ "$foo_lock_commit" = "$foo_commit" ]
 
-bar_lock_commit=$(jq -r '.bar.commit' wit-lock.json)
+bar_lock_commit=$(jq -r '.[] | select(.name=="bar") | .commit' wit-lock.json)
 check "ws-lock.json should contain correct bar commit" [ "$bar_lock_commit" = "$bar_commit" ]
 
 report

--- a/t/repo_path_nosource.t
+++ b/t/repo_path_nosource.t
@@ -56,10 +56,10 @@ check "foo should be pulled in as a dependency of bar" [ -d foo ]
 foo_ws_commit=$(git -C foo rev-parse HEAD)
 check "foo commit should match the dependency in bar" [ "$foo_ws_commit" = "$foo_commit" ]
 
-foo_lock_commit=$(jq -r '.foo.commit' wit-lock.json)
+foo_lock_commit=$(jq -r '.[] | select(.name=="foo") | .commit' wit-lock.json)
 check "ws-lock.json should contain correct foo commit" [ "$foo_lock_commit" = "$foo_commit" ]
 
-bar_lock_commit=$(jq -r '.bar.commit' wit-lock.json)
+bar_lock_commit=$(jq -r '.[] | select(.name=="bar") | .commit' wit-lock.json)
 check "ws-lock.json should contain correct bar commit" [ "$bar_lock_commit" = "$bar_commit" ]
 
 report

--- a/t/repo_path_relative_root_pkg.t
+++ b/t/repo_path_relative_root_pkg.t
@@ -43,10 +43,10 @@ check "foo should be pulled in as a dependency of bar" [ -d foo ]
 foo_ws_commit=$(git -C foo rev-parse HEAD)
 check "foo commit should match the dependency in bar" [ "$foo_ws_commit" = "$foo_commit" ]
 
-foo_lock_commit=$(jq -r '.foo.commit' wit-lock.json)
+foo_lock_commit=$(jq -r '.[] | select(.name=="foo") | .commit' wit-lock.json)
 check "ws-lock.json should contain correct foo commit" [ "$foo_lock_commit" = "$foo_commit" ]
 
-bar_lock_commit=$(jq -r '.bar.commit' wit-lock.json)
+bar_lock_commit=$(jq -r '.[] | select(.name=="bar") | .commit' wit-lock.json)
 check "ws-lock.json should contain correct bar commit" [ "$bar_lock_commit" = "$bar_commit" ]
 
 report

--- a/t/sources_conflict_unresolvable.t
+++ b/t/sources_conflict_unresolvable.t
@@ -49,7 +49,7 @@ check "wit init with conflicting paths fails" [ $? -ne 0 ]
 
 echo $output
 
-echo $output | grep "Two dependencies have the same name"
+echo $output | grep "Two repositories have the same name"
 
 check "error message is somewhat descriptive" [ $? -eq 0 ]
 

--- a/t/wit_init_no_update.t
+++ b/t/wit_init_no_update.t
@@ -26,10 +26,10 @@ check "foo should be pulled in upon calling update" [ -d foo ]
 foo_ws_commit=$(git -C foo rev-parse HEAD)
 check "foo commit should match the dependency in bar" [ "$foo_ws_commit" = "$foo_commit" ]
 
-foo_lock_commit=$(jq -r '.foo.commit' wit-lock.json)
+foo_lock_commit=$(jq -r '.[] | select(.name=="foo") | .commit' wit-lock.json)
 check "ws-lock.json should contain correct foo commit" [ "$foo_lock_commit" = "$foo_commit" ]
 
-bar_lock_commit=$(jq -r '.bar.commit' wit-lock.json)
+bar_lock_commit=$(jq -r '.[] | select(.name=="bar") | .commit' wit-lock.json)
 check "ws-lock.json should contain correct bar commit" [ "$bar_lock_commit" = "$bar_commit" ]
 
 report

--- a/t/wit_update.t
+++ b/t/wit_update.t
@@ -26,10 +26,10 @@ check "foo should be pulled in as a dependency of bar" [ -d foo ]
 foo_ws_commit=$(git -C foo rev-parse HEAD)
 check "foo commit should match the dependency in bar" [ "$foo_ws_commit" = "$foo_commit" ]
 
-foo_lock_commit=$(jq -r '.foo.commit' wit-lock.json)
+foo_lock_commit=$(jq -r '.[] | select(.name=="foo") | .commit' wit-lock.json)
 check "ws-lock.json should contain correct foo commit" [ "$foo_lock_commit" = "$foo_commit" ]
 
-bar_lock_commit=$(jq -r '.bar.commit' wit-lock.json)
+bar_lock_commit=$(jq -r '.[] | select(.name=="bar") | .commit' wit-lock.json)
 check "ws-lock.json should contain correct bar commit" [ "$bar_lock_commit" = "$bar_commit" ]
 
 report

--- a/t/wit_update_pkg.t
+++ b/t/wit_update_pkg.t
@@ -48,7 +48,7 @@ check "Updating foo to a remote branch should work!" [ $? -eq 0 ]
 foo_manifest_commit=$(jq -r '.[] | select(.name=="foo") | .commit' wit-workspace.json)
 check "The manifest should contain the correct commit" [ "$foo_manifest_commit" = "$foo_commit_branch" ]
 
-foo_lock_commit=$(jq -r '.foo | .commit' wit-lock.json)
+foo_lock_commit=$(jq -r '.[] | select(.name=="foo") | .commit' wit-lock.json)
 check "Before running 'wit update', the lock should contain the old commit" [ "$foo_lock_commit" = "$foo_commit" ]
 
 wit update
@@ -57,7 +57,7 @@ check "wit update should succeed" [ $? -eq 0 ]
 commit=$(git -C foo rev-parse HEAD)
 check "foo should have checked out the right commit" [ "$commit" = "$foo_commit_branch" ]
 
-foo_lock_commit2=$(jq -r '.foo | .commit' wit-lock.json)
+foo_lock_commit2=$(jq -r '.[] | select(.name=="foo") | .commit' wit-lock.json)
 check "After 'wit update', the lock should contain the correct commit" [ "$foo_lock_commit2" = "$foo_commit_branch" ]
 
 report


### PR DESCRIPTION
I've produced a few revisions that I don't like, so just putting one up so we can talk about it

The idea is that all the json formats could be the same (commit 1), and that only one area of the codebase knows how to serialize the output and write the files (commit 2).

It makes the presumption that one format is good enough for the 3 use cases we have.
This *does* change the format used for `wit-lock.json` but I feel that's ok as its not typically committed to revision control like `wit-manifest.json`.

I haven't tried to refactor manifest.py/lock.py/dependancy.py/package.py too much, only enough to use RepoEntry.

Longer term I feel this helps us add more fields, like branch name and remote name.