### PR TITLE
Consolidate json format parsing

### DIFF
--- a/lib/wit/dependency.py
+++ b/lib/wit/dependency.py
@@ -3,11 +3,11 @@ import multiprocessing.dummy
 from datetime import datetime
 from pathlib import Path
 from typing import List  # noqa: F401
-from collections import OrderedDict
 from .common import WitUserError
-from .package import Package
-from .witlogger import getLogger
 from .gitrepo import BadSource
+from .package import Package
+from .repo_entries import RepoEntry
+from .witlogger import getLogger
 
 log = getLogger()
 
@@ -112,14 +112,12 @@ class Dependency:
         return datetime.utcfromtimestamp(int(self.package.repo.commit_to_time(
             self.specified_revision)))
 
-    def manifest(self):
-        res = OrderedDict()
-        res['name'] = self.name
-        res['source'] = self.source
-        res['commit'] = self.specified_revision
-        if self.message is not None and len(self.message) > 0:
-            res['//'] = self.message
-        return res
+    def to_repo_entry(self):
+        return RepoEntry(self.name, self.specified_revision, self.source, message=self.message)
+
+    @staticmethod
+    def from_repo_entry(entry):
+        return Dependency(entry.checkout_path, entry.remote_url, entry.revision, entry.message)
 
     # used before saving to manifests/lockfiles
     def resolved(self):
@@ -185,8 +183,3 @@ def parse_dependency_tag(s):
     rev = parts[1] if parts[1:] else None
 
     return source, rev
-
-
-def manifest_item_to_dep(obj):
-    # source can be done due to repo path
-    return Dependency(obj['name'], obj.get('source', None), obj['commit'], obj.get('//', None))

--- a/lib/wit/lock.py
+++ b/lib/wit/lock.py
@@ -1,18 +1,13 @@
 #!/usr/bin/env python3
 
-import json
 from .gitrepo import GitRepo
-from collections import OrderedDict
 from typing import Optional
 from .witlogger import getLogger
-from .package import Package
+from .repo_entries import RepoEntries
 
 log = getLogger()
 
 
-# TODO
-# Should we use different datastructures?
-# The JSON file format slightly differs from manifest, why?
 class LockFile:
     """
     Common class for the description of package dependencies and a workspace
@@ -35,29 +30,16 @@ class LockFile:
 
     def write(self, path):
         log.debug("Writing lock file to {}".format(path))
-        contents = OrderedDict((p.name, p.manifest()) for p in self.packages)
-        manifest_json = json.dumps(contents, sort_keys=True, indent=4) + '\n'
-        path.write_text(manifest_json)
+        contents = [p.to_repo_entry() for p in self.packages]
+        RepoEntries.write(path, contents)
 
     @staticmethod
     def read(path):
         log.debug("Reading lock file from {}".format(path))
-        content = json.loads(path.read_text())
-        return LockFile.process(content)
-
-    @staticmethod
-    def process(content):
-        pkgs = [lockfile_item_to_pkg(x) for _, x in content.items()]
-        return LockFile(pkgs)
+        from .package import Package
+        return LockFile([Package.from_repo_entry(x) for x in RepoEntries.read(path)])
 
 
 if __name__ == '__main__':
     import doctest
     doctest.testmod()
-
-
-def lockfile_item_to_pkg(item):
-    pkg = Package(item['name'], [])
-    pkg.set_source(item['source'])
-    pkg.revision = item['commit']
-    return pkg

--- a/lib/wit/manifest.py
+++ b/lib/wit/manifest.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
-import json
 from pathlib import Path
 from .witlogger import getLogger
+from .repo_entries import RepoEntries
 
 log = getLogger()
 
@@ -48,29 +48,18 @@ class Manifest:
         self.dependencies = newdeps
 
     def write(self, path):
-        contents = [p.manifest() for p in self.dependencies]
-        manifest_json = json.dumps(contents, sort_keys=True, indent=4) + '\n'
-        path.write_text(manifest_json)
+        contents = [d.to_repo_entry() for d in self.dependencies]
+        RepoEntries.write(path, contents)
 
     @staticmethod
     def read_manifest(path, safe=False):
         if safe and not Path(path).exists():
             return Manifest([])
-        content = json.loads(path.read_text())
-        return Manifest.process_manifest(content, path)
+        entries = RepoEntries.read(path)
 
-    @staticmethod
-    def process_manifest(json_content, location):
-        # Fail if there are dependencies with the same name
-        dep_names = [dep['name'] for dep in json_content]
-        if len(dep_names) != len(set(dep_names)):
-            dup = set([x for x in dep_names if dep_names.count(x) > 1])
-            raise Exception("Two dependencies have the same name in '{}': {}".format(location, dup))
-
-        # import here to prevent circular dependency
-        from .dependency import manifest_item_to_dep
-        dependencies = [manifest_item_to_dep(x) for x in json_content]
-        return Manifest(dependencies)
+        from .dependency import Dependency
+        deps = [Dependency.from_repo_entry(e) for e in entries]
+        return Manifest(deps)
 
 
 if __name__ == '__main__':

--- a/lib/wit/package.py
+++ b/lib/wit/package.py
@@ -4,8 +4,8 @@ from pathlib import Path
 import re
 import os
 import shutil
-from collections import OrderedDict
 from .gitrepo import GitRepo, BadSource
+from .repo_entries import RepoEntry
 from .witlogger import getLogger
 
 log = getLogger()
@@ -109,18 +109,22 @@ class Package:
         return source
 
     def get_dependencies(self):
-        manifest = self.repo.read_manifest_from_commit(self.revision)
-        deps = manifest.dependencies
+        from .dependency import Dependency
+        entries = self.repo.repo_entries_from_commit(self.revision)
+        deps = [Dependency.from_repo_entry(e) for e in entries]
         for dep in deps:
             dep.add_dependent(self)
         return deps
 
-    def manifest(self):
-        res = OrderedDict()
-        res['name'] = self.name
-        res['source'] = self.source
-        res['commit'] = self.revision
-        return res
+    def to_repo_entry(self):
+        return RepoEntry(self.name, self.revision, self.source)
+
+    @staticmethod
+    def from_repo_entry(entry):
+        pkg = Package(entry.checkout_path, [])
+        pkg.set_source(entry.remote_url)
+        pkg.revision = entry.revision
+        return pkg
 
     # this is in Package because update_dependency is in Package
     # it could be confusing to keep the two functions separate

--- a/lib/wit/repo_entries.py
+++ b/lib/wit/repo_entries.py
@@ -1,0 +1,114 @@
+import json
+import sys
+from enum import Enum
+from pathlib import Path
+from typing import List
+
+
+# The intent of Format, RepoEntry and List[RepoEntry] is that no other
+# parts of the codebase knows that json is used as the on-disk format, or know
+# any of the field names.
+
+# Version numbers will be encoded in the format from '3' onwards.
+class Format(Enum):
+    Lock = 1
+    Manifest = 2
+
+    @staticmethod
+    def from_path(path: Path):
+        if path.name == "wit-lock.json":
+            return Format.Lock
+        if path.name == "wit-workspace.json" or path.name == "wit-manifest.json":
+            return Format.Manifest
+        raise Exception("Unknown format for {}".format(str(path)))
+
+
+class RepoEntry:
+    def __init__(self, checkout_path, revision, remote_url, message=None):
+        # The path to checkout at within the workspace.
+        # JSON field name is 'name'.
+        self.checkout_path = checkout_path
+
+        # Desired revision that exists in the history of the below remote.
+        # JSON field name is 'commit'
+        self.revision = revision
+
+        # Url (or local fs path) for git to clone/fetch/push.
+        # JSON field name is 'source'
+        self.remote_url = remote_url
+
+        # A comment to leave in any serialized artifacts.
+        # Optional. JSON field name is '//'
+        self.message = message
+
+    def __repr__(self):
+        return str(self.__dict__)
+
+
+# OriginalEntry encodes the RepoEntry for both Lock and Manifest formats.
+class OriginalEntry():
+    @staticmethod
+    def to_dict(entry: RepoEntry) -> dict:
+        d = {
+            "name": entry.checkout_path,
+            "commit": entry.revision,
+            "source": entry.remote_url,
+        }
+        if entry.message:
+            d["//"] = entry.message
+        return d
+
+    @staticmethod
+    def from_dict(data: dict) -> RepoEntry:
+        return RepoEntry(data["name"],
+                         data["commit"],
+                         data.get("source"),  # 'repo path' cli option needs this optional
+                         data.get("//"))  # optional
+
+
+# Utilities for List[RepoEntry]
+class RepoEntries:
+    @staticmethod
+    def write(path: Path, entries: List[RepoEntry]):
+        fmt = Format.from_path(path)
+        if fmt is Format.Manifest:
+            manifest_data = [OriginalEntry.to_dict(e) for e in entries]
+            json_data = json.dumps(manifest_data, sort_keys=True, indent=4) + "\n"
+        if fmt is Format.Lock:
+            lock_data = dict((e.checkout_path, OriginalEntry.to_dict(e)) for e in entries)
+            json_data = json.dumps(lock_data, sort_keys=True, indent=4) + "\n"
+        path.write_text(json_data)
+
+    @staticmethod
+    def read(path: Path) -> List[RepoEntry]:
+        text = path.read_text()
+        # 'parse' has to be decoupled from 'read' as sometimes
+        # we read files directly from the git object store rather
+        # than the filesystem
+        return RepoEntries.parse(text, path, "")
+
+    @staticmethod
+    def parse(text: str, path: Path, rev: str) -> List[RepoEntry]:
+        try:
+            fromtext = json.loads(text)
+        except json.JSONDecodeError as e:
+            print("Failed to parse json in {}:{}: {}".format(path, rev, e.msg))
+            sys.exit(1)
+
+        entries = []
+        fmt = Format.from_path(path)
+        if fmt is Format.Manifest:
+            for entry in fromtext:
+                entries.append(OriginalEntry.from_dict(entry))
+        if fmt is Format.Lock:
+            for _, entry in fromtext.items():
+                entries.append(OriginalEntry.from_dict(entry))
+
+        # Check for duplicates
+        names = [entry.checkout_path for entry in entries]
+        if len(names) != len(set(names)):
+            dup = set([x for x in names if names.count(x) > 1])
+            print("Two repositories have same checkout path in {}:{}: {}".format(path, rev, dup))
+            sys.exit(1)
+
+        return entries

--- a/t/sources_conflict_unresolvable.t
+++ b/t/sources_conflict_unresolvable.t
@@ -49,7 +49,7 @@ check "wit init with conflicting paths fails" [ $? -ne 0 ]
 
 echo $output
 
-echo $output | grep "Two dependencies have the same name"
+echo $output | grep "Two repositories have same checkout path"
 
 check "error message is somewhat descriptive" [ $? -eq 0 ]
 


### PR DESCRIPTION
Unlike https://github.com/sifive/wit/pull/242 this does not change the formats.

These 3 file types now use the same parse/unparse/write/read code
- wit-manifest.json
- wit-lock.json
- wit-manifest.json

Most of the change is the addition of `repo_entries.py` and the rest of the changes are to use the new code from that file.

While formats themselves remain unchanged, this refactoring should make it easier for us to support new formats while maintaining compatibility.

As a future direction, I'm thinking that by checking the path name of a file we can know to write it as a, for example, `wit-lock.json`-style. 
Where as if it's called `new-format.toml` perhaps we could read out the version number from the current on-disk file to see what version we should write out.

