### PR TITLE
actions/init: add a new rule capable of initializing a wit workspace

### DIFF
--- a/actions/init/README.md
+++ b/actions/init/README.md
@@ -9,6 +9,20 @@ See [action.yml](./action.yml) for a detailed list of input parameters.
 
 ## Example Usage
 
+In the simplest scenario, something like this would work:
+```yaml
+jobs:
+  test:
+    name: Print daffy in workspace
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: sifive/wit/actions/init@v0.13.2
+    - run: echo "Daffy duck"
+```
+
+However, if you are using wake and have an environment packge to include,
+this is probably a more representative example:
 ```yaml
 jobs:
   test:

--- a/actions/init/README.md
+++ b/actions/init/README.md
@@ -1,9 +1,9 @@
 # Wit Init Action
 
 This [GitHub Action](https://github.com/features/actions) will initialize a
-wit workspace for a repository with a wit-manifest.json. An environment
-package should be specified to describe the build environment. By default,
-environment-example-sifive is used to support reading a JSON description.
+wit workspace for a repository with a wit-manifest.json.  When used in a
+complex project, an environment package should probably be specified to
+describe the build environment using the additional_packages argument.
 
 See [action.yml](./action.yml) for a detailed list of input parameters.
 
@@ -19,7 +19,7 @@ jobs:
     - name: Wit Init
       uses: sifive/wit/actions/init@v0.13.2
       with:
-        environment: git@github.com:sifive/environment-blockci-sifive.git::0.7.0
+        additional_packages: git@github.com:sifive/environment-blockci-sifive.git::0.7.0
 
     - name: Run wake scala compile
       uses: sifive/environment-blockci-sifive/actions/wake@0.7.0

--- a/actions/init/README.md
+++ b/actions/init/README.md
@@ -1,0 +1,28 @@
+# Wit Init Action
+
+This [GitHub Action](https://github.com/features/actions) will initialize a
+wit workspace for a repository with a wit-manifest.json. An environment
+package should be specified to describe the build environment. By default,
+environment-example-sifive is used to support reading a JSON description.
+
+See [action.yml](./action.yml) for a detailed list of input parameters.
+
+## Example Usage
+
+```yaml
+jobs:
+  test:
+    name: Scala compile
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Wit Init
+      uses: sifive/wit/actions/init@v0.13.2
+      with:
+        environment: git@github.com:sifive/environment-blockci-sifive.git::0.7.0
+
+    - name: Run wake scala compile
+      uses: sifive/environment-blockci-sifive/actions/wake@0.7.0
+      with:
+        command: -x 'compileScalaModule myScalaModule | getPathResult'
+```

--- a/actions/init/action.yml
+++ b/actions/init/action.yml
@@ -1,0 +1,57 @@
+name: 'Wit Init'
+description: 'Initialize a wit workspace including the github project which invokes this action'
+inputs:
+  workspace:
+    description: |
+      The location where wit will initialize the workspace. All repositories,
+      including the invoking repository, will be subdirections of workspace.
+    required: false
+    default: '.'
+  environment:
+    description: |
+      The environment package to use when building this repository. This project
+      will be automatically added to the wit workspace
+    required: false
+    default: 'git@github.com:sifive/environment-example-sifive.git'
+  force_github_https:
+    description: |
+      If set to true then rewrite all git@github.com URLs to
+      https://github.com.  This is useful for cloning public GitHub
+      repositories without requiring SSH credentials.
+    required: false
+    default: true
+  http_auth_username:
+    description: |
+      For HTTP Basic Authentication, the username to authenticate with. Must be used
+      with force_github_https. Defaults to the value used by GitHub for HTTP
+      authentication with GitHub Personal Access Tokens.
+    required: false
+    default: 'x-access-token'
+  http_auth_token:
+    description: |
+      For HTTP Basic Authentication, the password or token to authenticate with.
+      Must be used with force_github_https.
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        set -euo pipefail
+        if ${{ inputs.force_github_https }}; then
+          # Don't echo the token
+          set +x
+          if [[ -n "${{ inputs.http_auth_token }}" ]]; then
+            git config --global url."https://${{ inputs.http_auth_username }}:${{ inputs.http_auth_token }}@github.com/".insteadOf 'git@github.com:'
+          else
+            git config --global url.'https://github.com/'.insteadOf 'git@github.com:'
+          fi
+          set -x
+        fi
+        ${{ github.action_path }}/../../wit init ${{ inputs.workspace }}
+        ${{ github.action_path }}/../../wit -C ${{ inputs.workspace }} add-pkg git@github.com:${{ github.repository }}.git::${{ github.sha }}
+        ${{ github.action_path }}/../../wit -C ${{ inputs.workspace }} add-pkg ${{ inputs.environment }}
+        repo="${{ github.repository }}"; git -C ${{ inputs.workspace }}/.wit/${repo#*/} fetch origin ${{ github.sha }}
+        ${{ github.action_path }}/../../wit -C ${{ inputs.workspace }} update
+      shell: bash

--- a/actions/init/action.yml
+++ b/actions/init/action.yml
@@ -7,12 +7,12 @@ inputs:
       including the invoking repository, will be subdirections of workspace.
     required: false
     default: '.'
-  environment:
+  additional_packages:
     description: |
-      The environment package to use when building this repository. This project
-      will be automatically added to the wit workspace
+      Include additional repositories into the wit workpace.  This argument
+      expects a space separated list of repositories to include.
     required: false
-    default: 'git@github.com:sifive/environment-example-sifive.git'
+    default: ''
   force_github_https:
     description: |
       If set to true then rewrite all git@github.com URLs to
@@ -51,7 +51,7 @@ runs:
         fi
         ${{ github.action_path }}/../../wit init ${{ inputs.workspace }}
         ${{ github.action_path }}/../../wit -C ${{ inputs.workspace }} add-pkg git@github.com:${{ github.repository }}.git::${{ github.sha }}
-        ${{ github.action_path }}/../../wit -C ${{ inputs.workspace }} add-pkg ${{ inputs.environment }}
+        for i in ${{ inputs.additional_packages }}; do ${{ github.action_path }}/../../wit -C ${{ inputs.workspace }} add-pkg $i; done
         repo="${{ github.repository }}"; git -C ${{ inputs.workspace }}/.wit/${repo#*/} fetch origin ${{ github.sha }}
         ${{ github.action_path }}/../../wit -C ${{ inputs.workspace }} update
       shell: bash


### PR DESCRIPTION
This makes checking out a wit workspace a one-liner:
```yaml
  - uses: sifive/wit/actions/init@v0.13.2
```

If you want to run wake on the workspace, you can also specify an environment package like this:
```yaml
 jobs:
   test:
     name: Scala compile
     runs-on: ubuntu-latest

     steps:
     - name: Wit Init
       uses: sifive/wit/actions/init@v0.13.2
       with:
         additional_packages: git@github.com:sifive/environment-blockci-sifive.git::0.7.0

     - name: Run wake scala compile
       uses: sifive/environment-blockci-sifive/actions/wake@0.7.0
       with:
         command: -x 'compileScalaModule myScalaModule | getPathResult'
 ```