### PR TITLE
Error out gracefully when failing to clone a dependency

### DIFF
--- a/lib/wit/dependency.py
+++ b/lib/wit/dependency.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import List  # noqa: F401
 from .common import WitUserError
-from .gitrepo import BadSource
 from .package import Package
 from .repo_entries import RepoEntry
 from .witlogger import getLogger

--- a/lib/wit/dependency.py
+++ b/lib/wit/dependency.py
@@ -45,6 +45,8 @@ class Dependency:
         log.debug("Dependencies for [{}]: [{}]".format(self.name, subdeps))
 
         errors = self._parallel_clone(subdeps, wsroot, repo_paths, download, jobs)
+        if len(errors) > 0:
+            return {}, [], [], errors
 
         for subdep in subdeps:
             subdep.load(packages, repo_paths, wsroot, download=False)
@@ -72,7 +74,7 @@ class Dependency:
             try:
                 p = Package(dep.name, repo_paths)
                 p.load(wsroot, download, dep.source, dep.specified_revision)
-            except BadSource as e:
+            except Exception as e:
                 errors.append(e)
 
         with multiprocessing.dummy.Pool(jobs) as pool:

--- a/lib/wit/workspace.py
+++ b/lib/wit/workspace.py
@@ -196,6 +196,9 @@ class WorkSpace:
                 dep.resolve_deps(self.root, self.repo_paths, download, source_map,
                                  packages, queue, self.jobs)
 
+            if len(errors + dep_errors) > 0:
+                return {}, errors + dep_errors
+
         for pkg in packages.values():
             if not pkg.repo or pkg.repo.path.parts[-2] == '.wit':
                 continue

--- a/t/wit_bad_dep_source.t
+++ b/t/wit_bad_dep_source.t
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+. $(dirname $0)/test_util.sh
+
+prereq "on"
+
+START_DIR=$PWD
+
+make_repo 'parent'
+make_repo 'depend'
+depend_dir="$PWD/depend"
+
+prereq "off"
+
+
+##############
+# Adding a dependency
+
+wit init ws -a ./parent
+cd ws
+
+cd parent
+wit add-dep ${depend_dir}
+git commit -am "add dep"
+git push origin HEAD:main
+cd ..
+
+##############
+# Trying to clone the dependency, but its missing now
+
+cd $START_DIR
+rm -rf depend
+wit init ws2 -a ./parent &> out
+RES=$?
+check "fail to clone with the missing dependency" [ $RES -ne 0 ]
+
+grep -q "Bad remote" out
+RES=$?
+check "error message should highlight issue" [ $RES -eq 0 ]
+
+


### PR DESCRIPTION
This addresses the case where a package's dependency is unable to be cloned, but where it would still attempt to checkout a revision.
The message looked like
```
File "/usr/local/lib/python3.8/site-packages/wit/package.py", line 133, in checkout
    current_origin = self.repo.get_remote()
AttributeError: 'NoneType' object has no attribute 'get_remote'
```

This now returns errors after the parallel clone more eagerly
Error now looks like:
```
Creating new workspace [/home/user/workspace]
Cloned product1
The workspace now depends on 'product1::abcd123'
Cloned foo

--- ERROR ---
Bad remote for 'baa':
  git@github.com:sifive/baa
```
