### PR TITLE
Revert to previous subdeb.load behaviour

### DIFF
--- a/lib/wit/dependency.py
+++ b/lib/wit/dependency.py
@@ -48,7 +48,7 @@ class Dependency:
             return {}, [], [], errors
 
         for subdep in subdeps:
-            subdep.load(packages, repo_paths, wsroot, download=False)
+            subdep.load(packages, repo_paths, wsroot, download)
             sources_conflict_check(subdep, source_map)
             source_map[subdep.name] = subdep.package.resolve_source(subdep.source)
 


### PR DESCRIPTION
In wit 13 we've been getting an error that looks like the below when we specify a bad revision in our wit-manifest.json
```
File "/scratch/matthewc/wit/lib/wit/package.py", line 137, in checkout
    current_origin = self.repo.get_remote()
AttributeError: 'NoneType' object has no attribute 'get_remote'
```
This is what the error used to look like
```
wit.gitrepo.GitError: Command [git log -n1 --format=%ct 531e530646a58dfee78c2c0ad2124800fe36d610] in [/scratch/matthewc/soc-sesame-sifive-ws2/.wit/api-soctemplate-sifive] exited with non-zero exit status [128]
stdout: []
stderr: [fatal: bad object 531e530646a58dfee78c2c0ad2124800fe36d610]
```
This error message regression was introduced in #222. 

In #222 I was thinking that since we've 'downloaded' all the git repo's that we need, that the `subdep` load will behave the same but without a `git clone` if we set `download=False` (and it should have only been a mild optimisation where we don't try to re-bind a package to a git repo each time).
Reading the further downstream logic I don't think this is true, and rather than trying to refactor it right now I feel we should atleast enable the old behaviour
