### PR TITLE
Use git submodules as a source of dependencies

### DIFF
--- a/lib/wit/version.py
+++ b/lib/wit/version.py
@@ -1,2 +1,2 @@
 # This is the version reported by 'wit --version' when running outside a git repository
-__version__ = "0.13.dev0"
+__version__ = "0.14.dev0"


### PR DESCRIPTION

## what
* If repository lacks `wit-manifest.json`, use git submodules to collect dependency data
* `wit-manifest.json` is used in preference to git submodules, for repositories that have both
* `wit add-dep`/`wit update-dep` on a repository that only has git submodules errors out with a message, user would use regular git submodules commands to update those dependencies. These are the only two commands that should be impacted.

## why
* in repositories that already keep a wit-manifest.json and a list of submodules manually sync-ed, we could delete the wit-manifest.json file (presuming they used a new enough wit version). It might not make sense in all cases to do this but the option is there

## how
When wit is performing a `resolve` to determine which is the correct commit to checkout, it checks for the wit-manifest as usual, if this is missing it checks for a `.gitmodules` file.
The .gitmodules file provides the list of remote url and the within-repository path, for each submodule.
The within-repository path is used to ask the git index what the pointed-to commit is for the submodule.

## relationship to submodules
This could be viewed as creating a read-only on-demand wit-manifest.json from the submodule information.
Wit makes no attempt to write submodule information. 
Submodules do appear in the wit-lock.json, but wit does not know they are submodules.