### PR TITLE
Disallow relative paths in WIT_WORKSPACE_REFERENCE

### DIFF
--- a/lib/wit/main.py
+++ b/lib/wit/main.py
@@ -21,6 +21,7 @@ from .inspect import inspect_tree
 from pathlib import Path
 from typing import cast, List, Tuple  # noqa: F401
 from .common import error, WitUserError, print_errors
+from .env import git_reference_workspace
 from .gitrepo import GitRepo, GitCommitNotFound
 from .manifest import Manifest
 from .package import WitBug
@@ -36,6 +37,11 @@ class NotAPackageError(WitUserError):
 
 
 def main() -> None:
+
+    if git_reference_workspace and not Path(git_reference_workspace).is_absolute():
+        log.error("Environment variable $WIT_WORKSPACE_REFERENCE contains a relative path: "
+                  "'{}'. Please use an absolute path.".format(git_reference_workspace))
+        sys.exit(1)
 
     args = parser.parse_args()
     if args.verbose >= 4:

--- a/lib/wit/parser.py
+++ b/lib/wit/parser.py
@@ -20,7 +20,10 @@ def chdir(s) -> None:
 # ********** top-level parser **********
 parser = argparse.ArgumentParser(
     prog='wit',
-    formatter_class=argparse.RawTextHelpFormatter)
+    formatter_class=argparse.RawTextHelpFormatter,
+    description="Wit is a git repository workspace manager.\n\n"
+                "Use env var WIT_WORKSPACE_REFERENCE to point to another"
+                " workspace to use a cache for faster git clones.")
 parser.add_argument('-v', '--verbose', action='count', default=0,
                     help='''Specify level of verbosity
 -v:    verbose


### PR DESCRIPTION
Resolve a relative path in `$WIT_WORKSPACE_REFERENCE` into an absolute path.

Also, mention that the variable exists in `--help` as the markdown docs are less convenient 

For https://github.com/sifive/wit/issues/234 