### PR TITLE
Allow submodules to be ignored by reading .gitmodule metadata

### DIFF
--- a/doc/how-to-guides.adoc
+++ b/doc/how-to-guides.adoc
@@ -110,3 +110,39 @@ restore
     $ ls
     wit-lock.json wit-workspace.json
     $ wit restore
+
+== Specify dependencies via git submodules
+
+Some repositories that you would like to use as a dependency already use git submodules.
+Wit can read the git subomodule metadata from the repository as if it were a `wit-manifest.json`
+file.
+Wit will only read submodule data when there is no `wit-manifest.json` file.
+
+This is intended as a convenience only. While wit can *read* the depencency metadata
+it can not *write* the metadata. So functionality like `wit update-dep` will not update
+submodule metadata in those particular repositories, while otherwise still functioning
+normally in other dependency repositories.
+
+== Ignore git submodules
+
+=== Ignore all git submodules
+
+Provide a valid `wit-manifest.json` file.
+This can be produced when using `wit add-dep` if you have a dependency to add.
+Otherwise, you can provide a wit-manifest.json file containing only `[]`.
+
+=== Ignore a specific git submodule
+
+In a `.gitmodules` file within your repository, you can add a line
+to the git submodule: `wit = ignore`
+
+    $ cat workspace/foo/.gitmodules
+    [submodule "baa"]
+        path = baa
+        url = https://github.com/baa-corp/baa.git
+        wit = ignore
+
+This is only a local effect, it's the equivelant of deleting an entry in the `wit-manifest.json`.
+If another repository were to have `baa` as a dependency without a `wit = ignore` then `baa`
+will still appear in the workspace, but the metadata for which revision to use will ignore the
+input of `foo`

--- a/lib/wit/gitrepo.py
+++ b/lib/wit/gitrepo.py
@@ -325,7 +325,7 @@ class GitRepo:
     def _should_ignore_submodule(self, name, gitconfig):
         """
         In a repository that has deliberately removed/not-added a wit-manifest.json,
-        we can still read additional metadata for the repository from the .gitmodules
+        we can still read additional metadata for the dependency from .gitmodules
         Here we check if the submodule should be ignored and thereby not considered
         as a wit dependency.
         """

--- a/lib/wit/gitrepo.py
+++ b/lib/wit/gitrepo.py
@@ -300,6 +300,9 @@ class GitRepo:
 
         submodules = []
         for name_key, path in paths_by_name.items():
+            if self._should_ignore_submodule(name_key, proc.stdout):
+                continue
+
             # We use the relative path within the repository to ask the git index
             # for the pointer that's currently commited
             submodule_ref = self._get_submodule_pointer(revision, path)
@@ -318,6 +321,17 @@ class GitRepo:
             submodules.append(RepoEntry(name, submodule_ref, url))
 
         return submodules
+
+    def _should_ignore_submodule(self, name, gitconfig):
+        """
+        In a repository that has deliberately removed/not-added a wit-manifest.json,
+        we can still read additional metadata for the repository from the .gitmodules
+        Here we check if the submodule should be ignored and thereby not considered
+        as a wit dependency.
+        """
+        if "submodule.{}.wit ignore".format(name) in gitconfig:
+            return True
+        return False
 
     def _get_submodule_pointer(self, revision, path):
         """

--- a/t/wit_submodule_ignore.t
+++ b/t/wit_submodule_ignore.t
@@ -1,0 +1,49 @@
+#!/bin/sh
+. $(dirname $0)/test_util.sh
+prereq on
+
+
+# Set up repo foo to use as a package
+make_repo 'foo'
+foo_dir=$PWD/foo
+
+# 'baa' to use as wit-manifest-dependency of 'foo'
+make_repo 'baa'
+baa_dir=$PWD/baa
+
+# 'xyz' to use as submodule dependency of 'baa'
+make_repo 'xyz'
+xyz_dir=$PWD/xyz
+
+# add xyz as submodule dependency of baa, but ignored
+(
+  cd $baa_dir
+  git submodule add $xyz_dir
+  printf "\twit = ignore\n" >> .gitmodules
+  git commit -am "add submodule dep"
+)
+baa_commit=$(git -C baa rev-parse HEAD)
+
+# add baa as wit-dependency of foo
+(
+  cd $foo_dir
+  echo "[{\"name\":\"baa\", \"commit\":\"$baa_commit\", \"source\":\"$baa_dir\"}]" > wit-manifest.json
+  git add wit-manifest.json
+  git commit -m "add wit dep"
+)
+
+
+prereq off
+
+wit init ws -a $foo_dir
+RES=$?
+check "wit init should work" [ $RES -eq 0 ]
+
+cd ws
+
+ls | grep xyz
+RES=$?
+check "ignored repo should not be found in workspace" [ $RES -eq 1 ]
+
+report
+finish


### PR DESCRIPTION
Allow a user to specify that a git submodule of a repository should not be considered as input to the dependency resolution algo, by adding a key/val pair to `.gitmodules`

```
$ cat workspace/foo/.gitmodules
[submodule "baa"]
    path = baa
    url = https://github.com/baa-corp/baa.git
    wit = ignore
```