### PR TITLE
Add wit inspect --dot --simple.

### DIFF
--- a/doc/how-to-guides.adoc
+++ b/doc/how-to-guides.adoc
@@ -93,6 +93,9 @@ wit inspect --dot | dot -Tsvg > graph.svg
 
 This SVG file can be directly viewed in most web browsers.
 
+There is also a `--simple` option for `--dot` mode, which constructs a simpler
+version of the graph.
+
 
 == Restore a previous workspace
 

--- a/lib/wit/main.py
+++ b/lib/wit/main.py
@@ -108,7 +108,7 @@ def main() -> None:
                 if args.dot or args.tree:
                     inspect_tree(ws, args)
                 else:
-                    log.error('`wit inspect` must be run with a flag')
+                    log.error('`wit inspect` must be run with --dot or --tree')
                     print(parser.parse_args('inspect -h'.split()))
                     sys.exit(1)
     except WitUserError as e:

--- a/lib/wit/parser.py
+++ b/lib/wit/parser.py
@@ -117,6 +117,13 @@ inspect_parser = subparsers.add_parser('inspect', help='inspect lockfile')
 inspect_group = inspect_parser.add_mutually_exclusive_group()
 inspect_group.add_argument('--tree', action="store_true")
 inspect_group.add_argument('--dot', action="store_true")
+# Common to all
+inspect_parser.add_argument(
+    '--simple',
+    action='store_true',
+    help='Print simple view. When used with --dot, this will collapse all versions of a dependency'
+         ' into a single node.'
+)
 
 # ********** foreach subparser **********
 foreach_parser = subparsers.add_parser(


### PR DESCRIPTION
This adds a `--simple` mode for `wit inspect --dot` that collapses all the versions of the same package into a single node, which makes it easier to read the output graph, especially for larger graphs that have multiple dependencies on the same package.

I haven't thoroughly tested this other than running it with the new flag and lightly inspecting the output graph.